### PR TITLE
Add non-allocated tracing

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FieldTracer"
 uuid = "05065131-34d1-456a-ba22-faf972bb2934"
 authors = ["Hongyang Zhou <hyzhou@umich.edu>"]
-version = "0.1.18"
+version = "0.1.19"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/FieldTracer.jl
+++ b/src/FieldTracer.jl
@@ -25,27 +25,27 @@ arguments are the same as in [`trace2d_euler`](@ref) and [`trace2d_rk4`](@ref).
 
 """
 	 trace(fieldx, fieldy, fieldz, startx, starty, startz, gridx, gridy, gridz;
-       alg=RK4(), kwargs...)
+		 alg=RK4(), kwargs...)
 
-    trace(fieldx, fieldy, fieldz, startx, starty, startz, grid::CartesianGrid;
+	 trace(fieldx, fieldy, fieldz, startx, starty, startz, grid::CartesianGrid;
 		 alg=RK4(), maxstep=20000, ds=0.01, gridtype="ndgrid", direction="both")
 
 Stream tracing on structured mesh with field in 3D array and grid in range.
 """
-function trace(args...; alg::Algorithm=RK4(), kwargs...)
-   if length(args) ≤ 6 # 2D
-      if alg isa RK4
-         trace2d_rk4(args...; kwargs...)
-      elseif alg isa Euler
-         trace2d_euler(args...; kwargs...)
-      end
-   else # 3D
-      if alg isa RK4
-         trace3d_rk4(args...; kwargs...)
-      elseif alg isa Euler
-         trace3d_euler(args...; kwargs...)
-      end
-   end
+function trace(args...; alg::Algorithm = RK4(), kwargs...)
+	if length(args) ≤ 6 # 2D
+		if alg isa RK4
+			trace2d_rk4(args...; kwargs...)
+		elseif alg isa Euler
+			trace2d_euler(args...; kwargs...)
+		end
+	else # 3D
+		if alg isa RK4
+			trace3d_rk4(args...; kwargs...)
+		elseif alg isa Euler
+			trace3d_euler(args...; kwargs...)
+		end
+	end
 
 end
 

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,37 +1,36 @@
 # Precompiling workloads
 
 @setup_workload begin
-   @compile_workload begin
-      x = range(0, 1, step=0.1)
-      y = range(0, 1, step=0.1)
-      # ndgrid
-      u, v = let
-         xgrid = [i for i in x, _ in y]
-         ygrid = [j for _ in x, j in y]
-         copy(xgrid), -copy(ygrid)
-      end
-      xstart = 0.1
-      ystart = 0.9
+	@compile_workload begin
+		x = range(0, 1, step = 0.1)
+		y = range(0, 1, step = 0.1)
+		# ndgrid
+		u, v = let
+			xgrid = [i for i in x, _ in y]
+			ygrid = [j for _ in x, j in y]
+			copy(xgrid), -copy(ygrid)
+		end
+		xstart = 0.1
+		ystart = 0.9
 
-      #xt, yt = FieldTracer.euler(150, 0.1, 0.1, 0.9, x, y, u, v)
-      xt, yt = trace(u, v, xstart, ystart, x, y;
-         maxstep=100, ds=0.1, direction="both", alg=Euler())
-      xt, yt = trace(u, v, xstart, ystart, x, y;
-         maxstep=100, ds=0.1, direction="both", alg=RK4())
+		xt, yt = trace(u, v, xstart, ystart, x, y;
+			maxstep = 100, ds = 0.1, direction = "both", alg = Euler())
+		xt, yt = trace(u, v, xstart, ystart, x, y;
+			maxstep = 100, ds = 0.1, direction = "both", alg = RK4())
 
-      x = range(0, 10, length=10)
-      y = range(0, 10, length=10)
-      z = range(0, 10, length=10)
-      bx = fill(1.0, length(x), length(y), length(z))
-      by = fill(1.0, length(x), length(y), length(z))
-      bz = fill(1.0, length(x), length(y), length(z))
-      xs, ys, zs = 1.0, 1.0, 1.0
-   
-      # Euler 2nd order
-      x1, y1, z1 = trace(bx, by, bz, xs, ys, zs, x, y, z;
-         maxstep=10, ds=0.2, direction="both", alg=Euler())
-      # RK4
-      x1, y1, z1 = trace(bx, by, bz, xs, ys, zs, x, y, z;
-         maxstep=10, ds=0.2, direction="both", alg=RK4())
-   end
+		x = range(0, 10, length = 10)
+		y = range(0, 10, length = 10)
+		z = range(0, 10, length = 10)
+		bx = fill(1.0, length(x), length(y), length(z))
+		by = fill(1.0, length(x), length(y), length(z))
+		bz = fill(1.0, length(x), length(y), length(z))
+		xs, ys, zs = 1.0, 1.0, 1.0
+
+		# Euler 2nd order
+		x1, y1, z1 = trace(bx, by, bz, xs, ys, zs, x, y, z;
+			maxstep = 10, ds = 0.2, direction = "both", alg = Euler())
+		# RK4
+		x1, y1, z1 = trace(bx, by, bz, xs, ys, zs, x, y, z;
+			maxstep = 10, ds = 0.2, direction = "both", alg = RK4())
+	end
 end

--- a/src/structured2d.jl
+++ b/src/structured2d.jl
@@ -1,208 +1,307 @@
 # 2D Field tracing on a regular grid.
 
 """
-    bilin_reg(x, y, Q00, Q01, Q10, Q11)
+	 bilin_reg(x, y, Q00, Q01, Q10, Q11)
 
 Bilinear interpolation for x1,y1=(0,0) and x2,y2=(1,1)
 Q's are surrounding points such that Q00 = F[0,0], Q10 = F[1,0], etc.
 """
 function bilin_reg(x, y, Q00, Q10, Q01, Q11)
-   mx = 1 - x
-   my = 1 - y
-   fout =
-      Q00 * mx * my +
-      Q10 * x  * my +
-      Q01 * y  * mx +
-      Q11 * x  * y
+	mx = 1 - x
+	my = 1 - y
+	fout =
+		Q00 * mx * my +
+		Q10 * x * my +
+		Q01 * y * mx +
+		Q11 * x * y
 end
 
 """
-    grid_interp(x, y, field, ix, iy)
+	 grid_interp(x, y, field, ix, iy)
 
 Interpolate a value at (x,y) in a field. `ix` and `iy` are indexes for x,y
 locations (0-based).
 """
 grid_interp(x, y, ix, iy, field::Array) =
-   bilin_reg(x-ix, y-iy,
-   field[ix+1, iy+1],
-   field[ix+2, iy+1],
-   field[ix+1, iy+2],
-   field[ix+2, iy+2])
+	bilin_reg(x-ix, y-iy,
+		field[ix+1, iy+1],
+		field[ix+2, iy+1],
+		field[ix+1, iy+2],
+		field[ix+2, iy+2])
 
 """
-    DoBreak(iloc, jloc, iSize, jSize)
+	 DoBreak(iloc, jloc, iSize, jSize)
 
 Check to see if we should break out of an integration.
 """
 function DoBreak(iloc, jloc, iSize, jSize)
-   ibreak = false
-   if iloc ≥ iSize-1 || jloc ≥ jSize-1; ibreak = true end
-   if iloc < 0 || jloc < 0; ibreak = true end
-   ibreak
+	ibreak = false
+	if iloc ≥ iSize-1 || jloc ≥ jSize-1
+		;
+		ibreak = true
+	end
+	if iloc < 0 || jloc < 0
+		;
+		ibreak = true
+	end
+	ibreak
 end
 
 "Create unit vectors of field."
 function normalize_field(ux, uy, dx, dy)
-   fx, fy = similar(ux), similar(uy)
-   dxInv, dyInv = 1/dx, 1/dy
-   @inbounds @simd for i in eachindex(ux)
-      uInv = 1.0 / hypot(ux[i]*dxInv, uy[i]*dyInv)
-      fx[i] = ux[i] * dxInv * uInv
-      fy[i] = uy[i] * dyInv * uInv
-   end
-   fx, fy
+	fx, fy = similar(ux), similar(uy)
+	dxInv, dyInv = 1/dx, 1/dy
+	@inbounds @simd for i in eachindex(ux)
+		uInv = hypot(ux[i]*dxInv, uy[i]*dyInv) |> inv
+		fx[i] = ux[i] * dxInv * uInv
+		fy[i] = uy[i] * dyInv * uInv
+	end
+
+	fx, fy
 end
 
 """
-    euler(maxstep, ds, startx, starty, xGrid, yGrid, ux, uy)
+	 normalize_component(ux, uy, dxInv, dyInv)
+
+Normalizes a single vector component using inverse grid spacings.
+"""
+function normalize_component(ux, uy, dxInv, dyInv)
+	# Calculate the inverse magnitude in scaled coordinates
+	uInv = hypot(ux*dxInv, uy*dyInv) |> inv
+	# Scale components by inverse grid spacing
+	ux_scaled = ux * dxInv * uInv
+	uy_scaled = uy * dyInv * uInv
+
+	ux_scaled, uy_scaled
+end
+
+"""
+	 grid_interp_normalized(x, y, ix, iy, ux_field::Array, uy_field::Array, dx, dy)
+
+Interpolate a *normalized* vector value at (x,y) in a field.
+`ix` and `iy` are 0-based integer indices for the bottom-left corner of the cell containing (x,y).
+Normalization is performed on the fly for the corner points.
+"""
+function grid_interp_normalized(x, y, ix, iy, ux_field::Array, uy_field::Array, dx, dy)
+	dxInv, dyInv = inv(dx), inv(dy)
+	# Get field values at the four corner points
+	ux00, uy00 = ux_field[ix+1, iy+1], uy_field[ix+1, iy+1]
+	ux10, uy10 = ux_field[ix+2, iy+1], uy_field[ix+2, iy+1]
+	ux01, uy01 = ux_field[ix+1, iy+2], uy_field[ix+1, iy+2]
+	ux11, uy11 = ux_field[ix+2, iy+2], uy_field[ix+2, iy+2]
+
+	# Normalize each corner point vector on the fly
+	fx00, fy00 = normalize_component(ux00, uy00, dxInv, dyInv)
+	fx10, fy10 = normalize_component(ux10, uy10, dxInv, dyInv)
+	fx01, fy01 = normalize_component(ux01, uy01, dxInv, dyInv)
+	fx11, fy11 = normalize_component(ux11, uy11, dxInv, dyInv)
+
+	# Relative coordinates within the cell [0, 1]
+	xrel = x - ix
+	yrel = y - iy
+
+	# Interpolate the normalized x and y components separately
+	fx_interp = bilin_reg(xrel, yrel, fx00, fx10, fx01, fx11)
+	fy_interp = bilin_reg(xrel, yrel, fy00, fy10, fy01, fy11)
+
+	fx_interp, fy_interp
+end
+
+
+"""
+	 euler(maxstep, ds, startx, starty, xGrid, yGrid, ux, uy, precompute=false)
 
 Fast 2D tracing using Euler's method. It takes at most `maxstep` with step size `ds` tracing
 the vector field given by `ux,uy` starting from `(startx,starty)` in the Cartesian grid
 specified by ranges `xGrid` and `yGrid`. Step size is in normalized coordinates within the
 range [0, 1]. Return footprints' coordinates in (`x`, `y`).
+If `precompute=true`, fall back to the preallocation version.
 """
-function euler(maxstep, ds, startx, starty, xGrid, yGrid, ux, uy)
-   @assert size(ux) == size(uy) "field array sizes must be equal!"
+function euler(maxstep, ds, startx, starty, xGrid, yGrid, ux, uy, precompute = false)
+	@assert size(ux) == size(uy) "field array sizes must be equal!"
 
-   x = Vector{eltype(startx)}(undef, maxstep)
-   y = Vector{eltype(starty)}(undef, maxstep)
+	x = Vector{eltype(startx)}(undef, maxstep)
+	y = Vector{eltype(starty)}(undef, maxstep)
 
-   iSize, jSize = size(xGrid,1), size(yGrid,1)
+	iSize, jSize = size(xGrid, 1), size(yGrid, 1)
 
-   # Get starting points in normalized/array coordinates
-   dx = xGrid[2] - xGrid[1]
-   dy = yGrid[2] - yGrid[1]
-   x[1] = (startx - xGrid[1]) / dx
-   y[1] = (starty - yGrid[1]) / dy
+	# Get starting points in normalized/array coordinates
+	dx = xGrid[2] - xGrid[1]
+	dy = yGrid[2] - yGrid[1]
+	x[1] = (startx - xGrid[1]) / dx
+	y[1] = (starty - yGrid[1]) / dy
 
-   # Create unit vectors from full vector field
-   f1, f2 = normalize_field(ux, uy, dx, dy)
+	if precompute # Create unit vectors from full vector field
+		f1, f2 = normalize_field(ux, uy, dx, dy)
+	end
 
-   nstep = 0
-   # Perform tracing using Euler's method
-   @inbounds for n in 1:maxstep-1
-      # Find surrounding points
-      ix = floor(Int, x[n])
-      iy = floor(Int, y[n])
+	nstep = 0
+	# Perform tracing using Euler's method
+	@inbounds for n in 1:(maxstep-1)
+		# Find surrounding points
+		ix = floor(Int, x[n])
+		iy = floor(Int, y[n])
 
-      # Break if we leave the domain
-      if DoBreak(ix, iy, iSize, jSize)
-         nstep = n; break
-      end
+		# Break if we leave the domain
+		if DoBreak(ix, iy, iSize, jSize)
+			nstep = n;
+			break
+		end
 
-      # Interpolate unit vectors to current location
-      fx = grid_interp(x[n], y[n], ix, iy, f1)
-      fy = grid_interp(x[n], y[n], ix, iy, f2)
+		# Interpolate unit vectors to current location
+		if precompute
+			fx = grid_interp(x[n], y[n], ix, iy, f1)
+			fy = grid_interp(x[n], y[n], ix, iy, f2)
+		else
+			fx, fy = grid_interp_normalized(x[n], y[n], ix, iy, ux, uy, dx, dy)
+		end
 
-      if isnan(fx) || isnan(fy) || isinf(fx) || isinf(fy)
-         nstep = n
-         break
-      end
+		if isnan(fx) || isnan(fy) || isinf(fx) || isinf(fy)
+			nstep = n
+			break
+		end
 
-      @muladd x[n+1] = x[n] + ds * fx
-      @muladd y[n+1] = y[n] + ds * fy
+		@muladd x[n+1] = x[n] + ds * fx
+		@muladd y[n+1] = y[n] + ds * fy
 
-      nstep = n
-   end
+		nstep = n
+	end
 
-   # Convert traced points to original coordinate system.
-   @inbounds @simd for i in 1:nstep
-      @muladd x[i] = x[i]*dx + xGrid[1]
-      @muladd y[i] = y[i]*dy + yGrid[1]
-   end
+	# Convert traced points to original coordinate system.
+	@inbounds @simd for i in 1:nstep
+		@muladd x[i] = x[i]*dx + xGrid[1]
+		@muladd y[i] = y[i]*dy + yGrid[1]
+	end
 
-   x[1:nstep], y[1:nstep]
+	x[1:nstep], y[1:nstep]
 end
 
 """
-    rk4(maxstep, ds, startx, starty, xGrid, yGrid, ux, uy)
+	 rk4(maxstep, ds, startx, starty, xGrid, yGrid, ux, uy, precompute=false)
 
 Fast and reasonably accurate 2D tracing with 4th order Runge-Kutta method and constant step
 size `ds`. See also [`euler`](@ref).
 """
-function rk4(maxstep, ds, startx, starty, xGrid, yGrid, ux, uy)
-   @assert size(ux) == size(uy) "field array sizes must be equal!"
+function rk4(maxstep, ds, startx, starty, xGrid, yGrid, ux, uy, precompute = false)
+	@assert size(ux) == size(uy) "field array sizes must be equal!"
 
-   x = Vector{eltype(startx)}(undef, maxstep)
-   y = Vector{eltype(starty)}(undef, maxstep)
+	x = Vector{eltype(startx)}(undef, maxstep)
+	y = Vector{eltype(starty)}(undef, maxstep)
 
-   iSize, jSize = size(xGrid,1), size(yGrid,1)
+	iSize, jSize = size(xGrid, 1), size(yGrid, 1)
 
-   # Get starting points in normalized/array coordinates
-   dx = xGrid[2] - xGrid[1]
-   dy = yGrid[2] - yGrid[1]
-   x[1] = (startx - xGrid[1]) / dx
-   y[1] = (starty - yGrid[1]) / dy
+	# Get starting points in normalized/array coordinates
+	dx = xGrid[2] - xGrid[1]
+	dy = yGrid[2] - yGrid[1]
+	x[1] = (startx - xGrid[1]) / dx
+	y[1] = (starty - yGrid[1]) / dy
 
-   # Create unit vectors from full vector field
-   fx, fy = normalize_field(ux, uy, dx, dy)
+	if precompute # Create unit vectors from full vector field
+		fx, fy = normalize_field(ux, uy, dx, dy)
+	end
 
-   nstep = 0
-   # Perform tracing using RK4
-   @inbounds for n in 1:maxstep-1
-      # SUBSTEP #1
-      ix = floor(Int, x[n])
-      iy = floor(Int, y[n])
-      if DoBreak(ix, iy, iSize, jSize); nstep = n; break end
+	nstep = 0
+	# Perform tracing using RK4
+	@inbounds for n in 1:(maxstep-1)
+		# SUBSTEP #1
+		ix = floor(Int, x[n])
+		iy = floor(Int, y[n])
+		if DoBreak(ix, iy, iSize, jSize)
+			;
+			nstep = n;
+			break
+		end
 
-      f1x = grid_interp(x[n], y[n], ix, iy, fx)
-      f1y = grid_interp(x[n], y[n], ix, iy, fy)
-      if isnan(f1x) || isnan(f1y) || isinf(f1x) || isinf(f1y)
-         nstep = n; break
-      end
-      # SUBSTEP #2
-      @muladd xpos = x[n] + f1x*ds*0.5
-      @muladd ypos = y[n] + f1y*ds*0.5
-      ix = floor(Int, xpos)
-      iy = floor(Int, ypos)
-      if DoBreak(ix, iy, iSize, jSize); nstep = n; break end
+		if precompute
+			f1x = grid_interp(x[n], y[n], ix, iy, fx)
+			f1y = grid_interp(x[n], y[n], ix, iy, fy)
+		else
+			f1x, f1y = grid_interp_normalized(x[n], y[n], ix, iy, ux, uy, dx, dy)
+		end
 
-      f2x = grid_interp(xpos, ypos, ix, iy, fx)
-      f2y = grid_interp(xpos, ypos, ix, iy, fy)
+		if isnan(f1x) || isnan(f1y) || isinf(f1x) || isinf(f1y)
+			nstep = n;
+			break
+		end
+		# SUBSTEP #2
+		@muladd xpos = x[n] + f1x*ds*0.5
+		@muladd ypos = y[n] + f1y*ds*0.5
+		ix = floor(Int, xpos)
+		iy = floor(Int, ypos)
+		if DoBreak(ix, iy, iSize, jSize)
+			;
+			nstep = n;
+			break
+		end
 
-      if isnan(f2x) || isnan(f2y) || isinf(f2x) || isinf(f2y)
-         nstep = n; break
-      end
-      # SUBSTEP #3
-      @muladd xpos = x[n] + f2x*ds*0.5
-      @muladd ypos = y[n] + f2y*ds*0.5
-      ix = floor(Int, xpos)
-      iy = floor(Int, ypos)
-      if DoBreak(ix, iy, iSize, jSize); nstep = n; break end
+		if precompute
+			f2x = grid_interp(xpos, ypos, ix, iy, fx)
+			f2y = grid_interp(xpos, ypos, ix, iy, fy)
+		else
+			f2x, f2y = grid_interp_normalized(xpos, ypos, ix, iy, ux, uy, dx, dy)
+		end
+		if isnan(f2x) || isnan(f2y) || isinf(f2x) || isinf(f2y)
+			nstep = n;
+			break
+		end
+		# SUBSTEP #3
+		@muladd xpos = x[n] + f2x*ds*0.5
+		@muladd ypos = y[n] + f2y*ds*0.5
+		ix = floor(Int, xpos)
+		iy = floor(Int, ypos)
+		if DoBreak(ix, iy, iSize, jSize)
+			;
+			nstep = n;
+			break
+		end
 
-      f3x = grid_interp(xpos, ypos, ix, iy, fx)
-      f3y = grid_interp(xpos, ypos, ix, iy, fy)
-      if isnan(f3x) || isnan(f3y) || isinf(f3x) || isinf(f3y)
-         nstep = n; break
-      end
+		if precompute
+			f3x = grid_interp(xpos, ypos, ix, iy, fx)
+			f3y = grid_interp(xpos, ypos, ix, iy, fy)
+		else
+			f3x, f3y = grid_interp_normalized(xpos, ypos, ix, iy, ux, uy, dx, dy)
+		end
+		if isnan(f3x) || isnan(f3y) || isinf(f3x) || isinf(f3y)
+			nstep = n;
+			break
+		end
 
-      # SUBSTEP #4
-      @muladd xpos = x[n] + f3x*ds
-      @muladd ypos = y[n] + f3y*ds
-      ix = floor(Int, xpos)
-      iy = floor(Int, ypos)
-      if DoBreak(ix, iy, iSize, jSize); nstep = n; break end
+		# SUBSTEP #4
+		@muladd xpos = x[n] + f3x*ds
+		@muladd ypos = y[n] + f3y*ds
+		ix = floor(Int, xpos)
+		iy = floor(Int, ypos)
+		if DoBreak(ix, iy, iSize, jSize)
+			;
+			nstep = n;
+			break
+		end
 
-      f4x = grid_interp(xpos, ypos, ix, iy, fx)
-      f4y = grid_interp(xpos, ypos, ix, iy, fy)
-      if isnan(f4x) || isnan(f4y) || isinf(f4x) || isinf(f4y)
-         nstep = n; break
-      end
+		if precompute
+			f4x = grid_interp(xpos, ypos, ix, iy, fx)
+			f4y = grid_interp(xpos, ypos, ix, iy, fy)
+		else
+			f4x, f4y = grid_interp_normalized(xpos, ypos, ix, iy, ux, uy, dx, dy)
+		end
+		if isnan(f4x) || isnan(f4y) || isinf(f4x) || isinf(f4y)
+			nstep = n;
+			break
+		end
 
-      # Peform the full step using all substeps
-      @muladd x[n+1] = x[n] + ds/6 * (f1x + f2x*2 + f3x*2 + f4x)
-      @muladd y[n+1] = y[n] + ds/6 * (f1y + f2y*2 + f3y*2 + f4y)
+		# Peform the full step using all substeps
+		@muladd x[n+1] = x[n] + ds/6 * (f1x + f2x*2 + f3x*2 + f4x)
+		@muladd y[n+1] = y[n] + ds/6 * (f1y + f2y*2 + f3y*2 + f4y)
 
-      nstep = n
-   end
+		nstep = n
+	end
 
-   # Convert traced points to original coordinate system.
-   @inbounds @simd for i in 1:nstep
-      @muladd x[i] = x[i]*dx + xGrid[1]
-      @muladd y[i] = y[i]*dy + yGrid[1]
-   end
+	# Convert traced points to original coordinate system.
+	@inbounds @simd for i in 1:nstep
+		@muladd x[i] = x[i]*dx + xGrid[1]
+		@muladd y[i] = y[i]*dy + yGrid[1]
+	end
 
-   x[1:nstep], y[1:nstep]
+	x[1:nstep], y[1:nstep]
 end
 
 """
@@ -215,32 +314,31 @@ The higher accuracy allows for larger step sizes `ds`. Step size is in normalize
 coordinates within the range [0,1]. See also [`trace2d_euler`](@ref).
 """
 function trace2d_rk4(fieldx, fieldy, startx, starty, gridx, gridy;
-   maxstep=20000, ds=0.01, gridtype="ndgrid", direction="both")
-   @assert ndims(gridx) == 1 "Grid must be given in 1D range or vector!"
+	maxstep = 20000, ds = 0.01, gridtype = "ndgrid", direction = "both")
+	@assert ndims(gridx) == 1 "Grid must be given in 1D range or vector!"
 
-   if gridtype == "ndgrid"
-      fx = fieldx
-      fy = fieldy
-   else # meshgrid
-      fx = permutedims(fieldx)
-      fy = permutedims(fieldy)
-   end
+	if gridtype == "ndgrid"
+		fx = fieldx
+		fy = fieldy
+	else # meshgrid
+		fx = permutedims(fieldx)
+		fy = permutedims(fieldy)
+	end
 
-   if direction == "forward"
-      xt, yt = rk4(maxstep, ds, startx, starty, gridx, gridy, fx, fy)
-   elseif direction == "backward"
-      xt, yt = rk4(maxstep, ds, startx, starty, gridx, gridy, -fx, -fy)
-   else
-      x1, y1 = rk4(floor(Int,maxstep/2), ds, startx, starty, gridx, gridy,
-         -fx, -fy)
-      blen = length(x1)
-      x2, y2 = rk4(maxstep-blen, ds, startx, starty, gridx, gridy, fx, fy)
-      # concatenate with duplicates removed
-      xt = vcat(reverse!(x1), x2[2:end])
-      yt = vcat(reverse!(y1), y2[2:end])
-   end
+	if direction == "forward"
+		xt, yt = rk4(maxstep, ds, startx, starty, gridx, gridy, fx, fy)
+	elseif direction == "backward"
+		xt, yt = rk4(maxstep, -ds, startx, starty, gridx, gridy, -fx, -fy)
+	else
+		x1, y1 = rk4(floor(Int, maxstep/2), -ds, startx, starty, gridx, gridy, fx, fy)
+		blen = length(x1)
+		x2, y2 = rk4(maxstep-blen, ds, startx, starty, gridx, gridy, fx, fy)
+		# concatenate with duplicates removed
+		xt = vcat(reverse!(x1), x2[2:end])
+		yt = vcat(reverse!(y1), y2[2:end])
+	end
 
-   xt, yt
+	xt, yt
 end
 
 """
@@ -254,45 +352,44 @@ in normalized coordinates within the range [0,1]. The field can be in both `mesh
 `ndgrid` (default) format. Supporting `direction` of {"both","forward","backward"}.
 """
 function trace2d_euler(fieldx, fieldy, startx, starty, gridx, gridy;
-   maxstep=20000, ds=0.01, gridtype="ndgrid", direction="both")
-   @assert ndims(gridx) == 1 "Grid must be given in 1D range or vector!"
+	maxstep = 20000, ds = 0.01, gridtype = "ndgrid", direction = "both")
+	@assert ndims(gridx) == 1 "Grid must be given in 1D range or vector!"
 
-   if gridtype == "ndgrid"
-      fx = fieldx
-      fy = fieldy
-   else # meshgrid
-      fx = permutedims(fieldx)
-      fy = permutedims(fieldy)
-   end
+	if gridtype == "ndgrid"
+		fx = fieldx
+		fy = fieldy
+	else # meshgrid
+		fx = permutedims(fieldx)
+		fy = permutedims(fieldy)
+	end
 
-   if direction == "forward"
-      xt, yt = euler(maxstep, ds, startx, starty, gridx, gridy, fx, fy)
-   elseif direction == "backward"
-      xt, yt = euler(maxstep, ds, startx, starty, gridx, gridy, -fx, -fy)
-   else
-      x1, y1 = euler(floor(Int,maxstep/2), ds, startx, starty, gridx, gridy,
-         -fx, -fy)
-      blen = length(x1)
-      x2, y2 = euler(maxstep-blen, ds, startx, starty, gridx, gridy, fx, fy)
-      # concatenate with duplicates removed
-      xt = vcat(reverse!(x1), x2[2:end])
-      yt = vcat(reverse!(y1), y2[2:end])
-   end
+	if direction == "forward"
+		xt, yt = euler(maxstep, ds, startx, starty, gridx, gridy, fx, fy)
+	elseif direction == "backward"
+		xt, yt = euler(maxstep, -ds, startx, starty, gridx, gridy, fx, fy)
+	else
+		x1, y1 = euler(floor(Int, maxstep/2), -ds, startx, starty, gridx, gridy, fx, fy)
+		blen = length(x1)
+		x2, y2 = euler(maxstep-blen, ds, startx, starty, gridx, gridy, fx, fy)
+		# concatenate with duplicates removed
+		xt = vcat(reverse!(x1), x2[2:end])
+		yt = vcat(reverse!(y1), y2[2:end])
+	end
 
-   xt, yt
+	xt, yt
 end
 
 """
-    trace2d_euler(fieldx, fieldy, startx, starty, grid::CartesianGrid; kwargs...)
+	 trace2d_euler(fieldx, fieldy, startx, starty, grid::CartesianGrid; kwargs...)
 """
 function trace2d_euler(fieldx, fieldy, startx, starty, grid::CartesianGrid;
-   kwargs...)
-   gridmin = coords(minimum(grid))
-   gridmax = coords(maximum(grid))
-   Δx = spacing(grid)
+	kwargs...)
+	gridmin = coords(minimum(grid))
+	gridmax = coords(maximum(grid))
+	Δx = spacing(grid)
 
-   gridx = range(gridmin.x.val, gridmax.x.val, step=Δx[1].val)
-   gridy = range(gridmin.y.val, gridmax.y.val, step=Δx[2].val)
+	gridx = range(gridmin.x.val, gridmax.x.val, step = Δx[1].val)
+	gridy = range(gridmin.y.val, gridmax.y.val, step = Δx[2].val)
 
-   trace2d_euler(fieldx, fieldy, startx, starty, gridx, gridy; kwargs...)
+	trace2d_euler(fieldx, fieldy, startx, starty, gridx, gridy; kwargs...)
 end

--- a/src/structured2d.jl
+++ b/src/structured2d.jl
@@ -37,11 +37,9 @@ Check to see if we should break out of an integration.
 function DoBreak(iloc, jloc, iSize, jSize)
 	ibreak = false
 	if iloc ≥ iSize-1 || jloc ≥ jSize-1
-		;
 		ibreak = true
 	end
 	if iloc < 0 || jloc < 0
-		;
 		ibreak = true
 	end
 	ibreak
@@ -144,7 +142,7 @@ function euler(maxstep, ds, startx, starty, xGrid, yGrid, ux, uy, precompute = f
 
 		# Break if we leave the domain
 		if DoBreak(ix, iy, iSize, jSize)
-			nstep = n;
+			nstep = n
 			break
 		end
 
@@ -207,8 +205,7 @@ function rk4(maxstep, ds, startx, starty, xGrid, yGrid, ux, uy, precompute = fal
 		ix = floor(Int, x[n])
 		iy = floor(Int, y[n])
 		if DoBreak(ix, iy, iSize, jSize)
-			;
-			nstep = n;
+			nstep = n
 			break
 		end
 
@@ -220,7 +217,7 @@ function rk4(maxstep, ds, startx, starty, xGrid, yGrid, ux, uy, precompute = fal
 		end
 
 		if isnan(f1x) || isnan(f1y) || isinf(f1x) || isinf(f1y)
-			nstep = n;
+			nstep = n
 			break
 		end
 		# SUBSTEP #2
@@ -229,8 +226,7 @@ function rk4(maxstep, ds, startx, starty, xGrid, yGrid, ux, uy, precompute = fal
 		ix = floor(Int, xpos)
 		iy = floor(Int, ypos)
 		if DoBreak(ix, iy, iSize, jSize)
-			;
-			nstep = n;
+			nstep = n
 			break
 		end
 
@@ -241,7 +237,7 @@ function rk4(maxstep, ds, startx, starty, xGrid, yGrid, ux, uy, precompute = fal
 			f2x, f2y = grid_interp_normalized(xpos, ypos, ix, iy, ux, uy, dx, dy)
 		end
 		if isnan(f2x) || isnan(f2y) || isinf(f2x) || isinf(f2y)
-			nstep = n;
+			nstep = n
 			break
 		end
 		# SUBSTEP #3
@@ -250,8 +246,7 @@ function rk4(maxstep, ds, startx, starty, xGrid, yGrid, ux, uy, precompute = fal
 		ix = floor(Int, xpos)
 		iy = floor(Int, ypos)
 		if DoBreak(ix, iy, iSize, jSize)
-			;
-			nstep = n;
+			nstep = n
 			break
 		end
 
@@ -262,7 +257,7 @@ function rk4(maxstep, ds, startx, starty, xGrid, yGrid, ux, uy, precompute = fal
 			f3x, f3y = grid_interp_normalized(xpos, ypos, ix, iy, ux, uy, dx, dy)
 		end
 		if isnan(f3x) || isnan(f3y) || isinf(f3x) || isinf(f3y)
-			nstep = n;
+			nstep = n
 			break
 		end
 
@@ -272,8 +267,7 @@ function rk4(maxstep, ds, startx, starty, xGrid, yGrid, ux, uy, precompute = fal
 		ix = floor(Int, xpos)
 		iy = floor(Int, ypos)
 		if DoBreak(ix, iy, iSize, jSize)
-			;
-			nstep = n;
+			nstep = n
 			break
 		end
 
@@ -284,7 +278,7 @@ function rk4(maxstep, ds, startx, starty, xGrid, yGrid, ux, uy, precompute = fal
 			f4x, f4y = grid_interp_normalized(xpos, ypos, ix, iy, ux, uy, dx, dy)
 		end
 		if isnan(f4x) || isnan(f4y) || isinf(f4x) || isinf(f4y)
-			nstep = n;
+			nstep = n
 			break
 		end
 

--- a/src/structured3d.jl
+++ b/src/structured3d.jl
@@ -1,69 +1,177 @@
 # 3D field tracing on a regular grid.
 
 """
-    trilin_reg(x, y, z, Q)
+	 trilin_reg(x, y, z, Q)
 
 Trilinear interpolation for x1,y1,z1=(0,0,0) and x2,y2,z2=(1,1,1)
 Q's are surrounding points such that Q000 = F[0,0,0], Q100 = F[1,0,0], etc.
 """
-function trilin_reg(x::T, y::T, z::T, Q000, Q100, Q010, Q110, Q001, Q101, Q011, Q111) where {T<:Real}
-   oneT = one(T)
-   mx = oneT - x
-   my = oneT - y
-   mz = oneT - z
-   fout =
-      Q000 * mx * my * mz +
-      Q100 * x  * my * mz +
-      Q010 * y  * mx * mz +
-      Q110 * x  * y  * mz +
-      Q001 * mx * my * z +
-      Q101 * x  * my * z +
-      Q011 * y  * mx * z +
-      Q111 * x  * y  * z
-end
-
-# Extension from 2d case
-function DoBreak(iloc::Int, jloc::Int, kloc::Int, iSize::Int, jSize::Int, kSize::Int)
-   ibreak = false
-   if iloc ≥ iSize-1 || jloc ≥ jSize-1 || kloc ≥ kSize-1; ibreak = true end
-   if iloc < 0 || jloc < 0 || kloc < 0; ibreak = true end
-   ibreak
-end
-
-"Create unit vectors of field in normalized coordinates."
-function normalize_field(ux::U, uy::U, uz::U, dx::V, dy::V, dz::V) where {U, V<:Real}
-   fx, fy, fz = similar(ux), similar(uy), similar(uz)
-   dxInv, dyInv, dzInv = 1/dx, 1/dy, 1/dz
-   @inbounds @simd for i in eachindex(ux)
-      uInv = hypot(ux[i]*dxInv, uy[i]*dyInv, uz[i]*dzInv) |> inv
-      fx[i] = ux[i] * dxInv * uInv
-      fy[i] = uy[i] * dyInv * uInv
-      fz[i] = uz[i] * dzInv * uInv
-   end
-   fx, fy, fz
+function trilin_reg(
+	x::T,
+	y::T,
+	z::T,
+	Q000,
+	Q100,
+	Q010,
+	Q110,
+	Q001,
+	Q101,
+	Q011,
+	Q111,
+) where {T <: Real}
+	oneT = one(T)
+	mx = oneT - x
+	my = oneT - y
+	mz = oneT - z
+	fout =
+		Q000 * mx * my * mz +
+		Q100 * x * my * mz +
+		Q010 * y * mx * mz +
+		Q110 * x * y * mz +
+		Q001 * mx * my * z +
+		Q101 * x * my * z +
+		Q011 * y * mx * z +
+		Q111 * x * y * z
 end
 
 """
-    grid_interp(x, y, z, ix, iy, iz, field)
+	 grid_interp(x, y, z, ix, iy, iz, field)
 
 Interpolate a value at (x,y,z) in a field. `ix`,`iy` and `iz` are indexes for x, y and z
 locations (0-based).
 """
-grid_interp(x::T, y::T, z::T, ix::Int, iy::Int, iz::Int, field::AbstractArray{U,3}) where
-   {T<:Real, U<:Number} =
-   trilin_reg(x-ix, y-iy, z-iz,
-      field[ix+1, iy+1, iz+1],
-      field[ix+2, iy+1, iz+1],
-      field[ix+1, iy+2, iz+1],
-      field[ix+2, iy+2, iz+1],
-      field[ix+1, iy+1, iz+2],
-      field[ix+2, iy+1, iz+2],
-      field[ix+1, iy+2, iz+2],
-      field[ix+2, iy+2, iz+2]
-   )
+grid_interp(
+	x::T,
+	y::T,
+	z::T,
+	ix::Int,
+	iy::Int,
+	iz::Int,
+	field::AbstractArray{U, 3},
+) where
+	{T <: Real, U <: Number} =
+	trilin_reg(x-ix, y-iy, z-iz,
+		field[ix+1, iy+1, iz+1],
+		field[ix+2, iy+1, iz+1],
+		field[ix+1, iy+2, iz+1],
+		field[ix+2, iy+2, iz+1],
+		field[ix+1, iy+1, iz+2],
+		field[ix+2, iy+1, iz+2],
+		field[ix+1, iy+2, iz+2],
+		field[ix+2, iy+2, iz+2],
+	)
+
+# Extension from 2d case
+function DoBreak(iloc::Int, jloc::Int, kloc::Int, iSize::Int, jSize::Int, kSize::Int)
+	ibreak = false
+	if iloc ≥ iSize-1 || jloc ≥ jSize-1 || kloc ≥ kSize-1
+		;
+		ibreak = true
+	end
+	if iloc < 0 || jloc < 0 || kloc < 0
+		;
+		ibreak = true
+	end
+	ibreak
+end
+
+"Create unit vectors of field in normalized coordinates."
+function normalize_field(ux::U, uy::U, uz::U, dx::V, dy::V, dz::V) where {U, V <: Real}
+	fx, fy, fz = similar(ux), similar(uy), similar(uz)
+	dxInv, dyInv, dzInv = 1/dx, 1/dy, 1/dz
+	@inbounds @simd for i in eachindex(ux)
+		uInv = hypot(ux[i]*dxInv, uy[i]*dyInv, uz[i]*dzInv) |> inv
+		fx[i] = ux[i] * dxInv * uInv
+		fy[i] = uy[i] * dyInv * uInv
+		fz[i] = uz[i] * dzInv * uInv
+	end
+	fx, fy, fz
+end
 
 """
-    euler(maxstep, ds, startx, starty, startz, xGrid, yGrid, zGrid, ux, uy, uz)
+	 normalize_component(ux, uy, uz, dxInv, dyInv, dzInv)
+
+Normalizes a single vector component using inverse grid spacings.
+"""
+function normalize_component(ux, uy, uz, dxInv, dyInv, dzInv)
+	# Calculate the inverse magnitude in scaled coordinates
+	uInv = hypot(ux*dxInv, uy*dyInv, uz*dzInv) |> inv
+	# Scale components by inverse grid spacing
+	ux_scaled = ux * dxInv * uInv
+	uy_scaled = uy * dyInv * uInv
+	uz_scaled = uz * dzInv * uInv
+
+	ux_scaled, uy_scaled, uz_scaled
+end
+
+"""
+	 grid_interp_normalized(x, y, z, ix, iy, iz, ux_field::Array, uy_field::Array, uz_field::Array, dx, dy, dz)
+
+Interpolate a *normalized* vector value at (x,y,z) in a field.
+`ix,iy,iz` are 0-based integer indices for the bottom-left corner of the cell containing (x,y,z).
+Normalization is performed on the fly for the corner points.
+"""
+function grid_interp_normalized(
+	x,
+	y,
+	z,
+	ix,
+	iy,
+	iz,
+	ux_field::Array,
+	uy_field::Array,
+	uz_field::Array,
+	dx,
+	dy,
+	dz,
+)
+	dxInv, dyInv, dzInv = inv(dx), inv(dy), inv(dz)
+	# Get field values at the 8 corner points
+	ux000, uy000, uz000 =
+		ux_field[ix+1, iy+1, iz+1], uy_field[ix+1, iy+1, iz+1], uz_field[ix+1, iy+1, iz+1]
+	ux100, uy100, uz100 =
+		ux_field[ix+2, iy+1, iz+1], uy_field[ix+2, iy+1, iz+1], uz_field[ix+2, iy+1, iz+1]
+	ux010, uy010, uz010 =
+		ux_field[ix+1, iy+2, iz+1], uy_field[ix+1, iy+2, iz+1], uz_field[ix+1, iy+2, iz+1]
+	ux110, uy110, uz110 =
+		ux_field[ix+2, iy+2, iz+1], uy_field[ix+2, iy+2, iz+1], uz_field[ix+2, iy+2, iz+1]
+	ux001, uy001, uz001 =
+		ux_field[ix+1, iy+1, iz+2], uy_field[ix+1, iy+1, iz+2], uz_field[ix+1, iy+1, iz+2]
+	ux101, uy101, uz101 =
+		ux_field[ix+2, iy+1, iz+2], uy_field[ix+2, iy+1, iz+2], uz_field[ix+2, iy+1, iz+2]
+	ux011, uy011, uz011 =
+		ux_field[ix+1, iy+2, iz+2], uy_field[ix+1, iy+2, iz+2], uz_field[ix+1, iy+2, iz+2]
+	ux111, uy111, uz111 =
+		ux_field[ix+2, iy+2, iz+2], uy_field[ix+2, iy+2, iz+2], uz_field[ix+2, iy+2, iz+2]
+
+	# Normalize each corner point vector on the fly
+	fx000, fy000, fz000 = normalize_component(ux000, uy000, uz000, dxInv, dyInv, dzInv)
+	fx100, fy100, fz100 = normalize_component(ux100, uy100, uz100, dxInv, dyInv, dzInv)
+	fx010, fy010, fz010 = normalize_component(ux010, uy010, uz010, dxInv, dyInv, dzInv)
+	fx110, fy110, fz110 = normalize_component(ux110, uy110, uz110, dxInv, dyInv, dzInv)
+	fx001, fy001, fz001 = normalize_component(ux001, uy001, uz001, dxInv, dyInv, dzInv)
+	fx101, fy101, fz101 = normalize_component(ux101, uy101, uz101, dxInv, dyInv, dzInv)
+	fx011, fy011, fz011 = normalize_component(ux011, uy011, uz011, dxInv, dyInv, dzInv)
+	fx111, fy111, fz111 = normalize_component(ux111, uy111, uz111, dxInv, dyInv, dzInv)
+
+	# Relative coordinates within the cell [0, 1]
+	xrel = x - ix
+	yrel = y - iy
+	zrel = z - iz
+
+	# Interpolate the normalized x,y,z components separately
+	fx_interp =
+		trilin_reg(xrel, yrel, zrel, fx000, fx100, fx010, fx110, fx001, fx101, fx011, fx111)
+	fy_interp =
+		trilin_reg(xrel, yrel, zrel, fy000, fy100, fy010, fy110, fy001, fy101, fy011, fy111)
+	fz_interp =
+		trilin_reg(xrel, yrel, zrel, fz000, fz100, fz010, fz110, fz001, fz101, fz011, fz111)
+
+	fx_interp, fy_interp, fz_interp
+end
+
+"""
+	 euler(maxstep, ds, startx, starty, startz, xGrid, yGrid, zGrid, ux, uy, uz, precompute=false)
 
 Fast 3D tracing using Euler's method. It takes at most `maxstep` with step size `ds` tracing
 the vector field given by `ux,uy,uz` starting from  `(startx,starty,startz)` in the
@@ -71,177 +179,222 @@ Cartesian grid specified by ranges `xGrid`, `yGrid` and `zGrid`.
 Return footprints' coordinates in (`x`,`y`,`z`).
 """
 function euler(maxstep::Int, ds::T, startx::T, starty::T, startz::T, xGrid, yGrid, zGrid,
-   ux, uy, uz) where T<:AbstractFloat
-   @assert size(ux) == size(uy) == size(uz) "field array sizes must be equal!"
+	ux, uy, uz, precompute = false) where T <: AbstractFloat
+	@assert size(ux) == size(uy) == size(uz) "field array sizes must be equal!"
 
-   x = Vector{eltype(startx)}(undef, maxstep)
-   y = Vector{eltype(starty)}(undef, maxstep)
-   z = Vector{eltype(startz)}(undef, maxstep)
+	x = Vector{eltype(startx)}(undef, maxstep)
+	y = Vector{eltype(starty)}(undef, maxstep)
+	z = Vector{eltype(startz)}(undef, maxstep)
 
-   iSize, jSize, kSize = size(xGrid,1), size(yGrid,1), size(zGrid,1)
+	iSize, jSize, kSize = size(xGrid, 1), size(yGrid, 1), size(zGrid, 1)
 
-   # Get starting points in normalized/array coordinates
-   dx = xGrid[2] - xGrid[1]
-   dy = yGrid[2] - yGrid[1]
-   dz = zGrid[2] - zGrid[1]
-   x[1] = (startx - xGrid[1]) / dx
-   y[1] = (starty - yGrid[1]) / dy
-   z[1] = (startz - zGrid[1]) / dz
+	# Get starting points in normalized/array coordinates
+	dx = xGrid[2] - xGrid[1]
+	dy = yGrid[2] - yGrid[1]
+	dz = zGrid[2] - zGrid[1]
+	x[1] = (startx - xGrid[1]) / dx
+	y[1] = (starty - yGrid[1]) / dy
+	z[1] = (startz - zGrid[1]) / dz
 
-   # Create unit vectors from full vector field
-   f1, f2, f3 = normalize_field(ux, uy, uz, dx, dy, dz)
+	if precompute # Create unit vectors from full vector field
+		f1, f2, f3 = normalize_field(ux, uy, uz, dx, dy, dz)
+	end
 
-   nstep = 0
-   # Perform tracing using Euler's method
-   @inbounds for n in 1:maxstep-1
-      # Find surrounding points
-      ix = floor(Int, x[n])
-      iy = floor(Int, y[n])
-      iz = floor(Int, z[n])
+	nstep = 0
+	# Perform tracing using Euler's method
+	@inbounds for n in 1:(maxstep-1)
+		# Find surrounding points
+		ix = floor(Int, x[n])
+		iy = floor(Int, y[n])
+		iz = floor(Int, z[n])
 
-      # Break if we leave the domain
-      if DoBreak(ix, iy, iz, iSize, jSize, kSize)
-         nstep = n; break
-      end
+		# Break if we leave the domain
+		if DoBreak(ix, iy, iz, iSize, jSize, kSize)
+			nstep = n;
+			break
+		end
 
-      # Interpolate unit vectors to current location
-      fx = grid_interp(x[n], y[n], z[n], ix, iy, iz, f1)
-      fy = grid_interp(x[n], y[n], z[n], ix, iy, iz, f2)
-      fz = grid_interp(x[n], y[n], z[n], ix, iy, iz, f3)
+		# Interpolate unit vectors to current location
+		if precompute
+			fx = grid_interp(x[n], y[n], z[n], ix, iy, iz, f1)
+			fy = grid_interp(x[n], y[n], z[n], ix, iy, iz, f2)
+			fz = grid_interp(x[n], y[n], z[n], ix, iy, iz, f3)
+		else
+			fx, fy, fz =
+				grid_interp_normalized(x[n], y[n], z[n], ix, iy, iz, ux, uy, uz, dx, dy, dz)
+		end
 
-      if any(isnan,[fx, fy, fz]) || any(isinf, [fx, fy, fz])
-         nstep = n
-         break
-      end
+		if any(isnan, [fx, fy, fz]) || any(isinf, [fx, fy, fz])
+			nstep = n
+			break
+		end
 
-      @muladd x[n+1] = x[n] + ds * fx
-      @muladd y[n+1] = y[n] + ds * fy
-      @muladd z[n+1] = z[n] + ds * fz
+		@muladd x[n+1] = x[n] + ds * fx
+		@muladd y[n+1] = y[n] + ds * fy
+		@muladd z[n+1] = z[n] + ds * fz
 
-      nstep = n
-   end
+		nstep = n
+	end
 
-   # Convert traced points to original coordinate system.
-   @inbounds @simd for i in 1:nstep
-      @muladd x[i] = x[i]*dx + xGrid[1]
-      @muladd y[i] = y[i]*dy + yGrid[1]
-      @muladd z[i] = z[i]*dz + zGrid[1]
-   end
-   x[1:nstep], y[1:nstep], z[1:nstep]
+	# Convert traced points to original coordinate system.
+	@inbounds @simd for i in 1:nstep
+		@muladd x[i] = x[i]*dx + xGrid[1]
+		@muladd y[i] = y[i]*dy + yGrid[1]
+		@muladd z[i] = z[i]*dz + zGrid[1]
+	end
+
+	x[1:nstep], y[1:nstep], z[1:nstep]
 end
 
 
 """
-    rk4(maxstep, ds, startx, starty, startz, xGrid, yGrid, zGrid, ux, uy, uz)
+	 rk4(maxstep, ds, startx, starty, startz, xGrid, yGrid, zGrid, ux, uy, uz, precompute=false)
 
 Fast and reasonably accurate 3D tracing with 4th order Runge-Kutta method and constant step
 size `ds`. See also [`euler`](@ref).
 """
 function rk4(maxstep::Int, ds::T, startx::T, starty::T, startz::T, xGrid, yGrid, zGrid,
-   ux, uy, uz) where T<:AbstractFloat
+	ux, uy, uz, precompute = false) where T <: AbstractFloat
 
-   @assert size(ux) == size(uy) == size(uz) "field array sizes must be equal!"
+	@assert size(ux) == size(uy) == size(uz) "field array sizes must be equal!"
 
-   x = Vector{eltype(startx)}(undef, maxstep)
-   y = Vector{eltype(starty)}(undef, maxstep)
-   z = Vector{eltype(startz)}(undef, maxstep)
+	x = Vector{eltype(startx)}(undef, maxstep)
+	y = Vector{eltype(starty)}(undef, maxstep)
+	z = Vector{eltype(startz)}(undef, maxstep)
 
-   iSize, jSize, kSize = size(xGrid,1), size(yGrid,1), size(zGrid,1)
+	iSize, jSize, kSize = size(xGrid, 1), size(yGrid, 1), size(zGrid, 1)
 
-   # Get starting points in normalized/array coordinates
-   dx = xGrid[2] - xGrid[1]
-   dy = yGrid[2] - yGrid[1]
-   dz = zGrid[2] - zGrid[1]
-   x[1] = (startx - xGrid[1]) / dx
-   y[1] = (starty - yGrid[1]) / dy
-   z[1] = (startz - zGrid[1]) / dz
+	# Get starting points in normalized/array coordinates
+	dx = xGrid[2] - xGrid[1]
+	dy = yGrid[2] - yGrid[1]
+	dz = zGrid[2] - zGrid[1]
+	x[1] = (startx - xGrid[1]) / dx
+	y[1] = (starty - yGrid[1]) / dy
+	z[1] = (startz - zGrid[1]) / dz
 
-   # Create unit vectors from full vector field
-   fx, fy, fz = normalize_field(ux, uy, uz, dx, dy, dz)
+	if precompute # Create unit vectors from full vector field
+		fx, fy, fz = normalize_field(ux, uy, uz, dx, dy, dz)
+	end
 
-   nstep = 0
-   # Perform tracing using RK4
-   @inbounds for n in 1:maxstep-1
-      # SUBSTEP #1
-      ix = floor(Int, x[n])
-      iy = floor(Int, y[n])
-      iz = floor(Int, z[n])
-      if DoBreak(ix, iy, iz, iSize, jSize, kSize); nstep = n; break end
+	nstep = 0
+	# Perform tracing using RK4
+	@inbounds for n in 1:(maxstep-1)
+		# SUBSTEP #1
+		ix = floor(Int, x[n])
+		iy = floor(Int, y[n])
+		iz = floor(Int, z[n])
+		if DoBreak(ix, iy, iz, iSize, jSize, kSize)
+			nstep = n
+			break
+		end
 
-      f1x = grid_interp(x[n], y[n], z[n], ix, iy, iz, fx)
-      f1y = grid_interp(x[n], y[n], z[n], ix, iy, iz, fy)
-      f1z = grid_interp(x[n], y[n], z[n], ix, iy, iz, fz)
-      if any(isnan,[f1x, f1y, f1z]) || any(isinf, [f1x, f1y, f1z])
-         nstep = n; break
-      end
-      # SUBSTEP #2
-      xpos = x[n] + f1x*ds/2.0
-      ypos = y[n] + f1y*ds/2.0
-      zpos = z[n] + f1z*ds/2.0
-      ix = floor(Int, xpos)
-      iy = floor(Int, ypos)
-      iz = floor(Int, zpos)
-      if DoBreak(ix, iy, iz, iSize, jSize, kSize); nstep = n; break end
+		if precompute
+			f1x = grid_interp(x[n], y[n], z[n], ix, iy, iz, fx)
+			f1y = grid_interp(x[n], y[n], z[n], ix, iy, iz, fy)
+			f1z = grid_interp(x[n], y[n], z[n], ix, iy, iz, fz)
+		else
+			f1x, f1y, f1z =
+				grid_interp_normalized(x[n], y[n], z[n], ix, iy, iz, ux, uy, uz, dx, dy, dz)
+		end
+		if any(isnan, [f1x, f1y, f1z]) || any(isinf, [f1x, f1y, f1z])
+			nstep = n
+			break
+		end
+		# SUBSTEP #2
+		xpos = x[n] + f1x*ds/2
+		ypos = y[n] + f1y*ds/2
+		zpos = z[n] + f1z*ds/2
+		ix = floor(Int, xpos)
+		iy = floor(Int, ypos)
+		iz = floor(Int, zpos)
+		if DoBreak(ix, iy, iz, iSize, jSize, kSize)
+			nstep = n
+			break
+		end
 
-      f2x = grid_interp(xpos, ypos, zpos, ix, iy, iz, fx)
-      f2y = grid_interp(xpos, ypos, zpos, ix, iy, iz, fy)
-      f2z = grid_interp(xpos, ypos, zpos, ix, iy, iz, fz)
-      if any(isnan,[f2x, f2y, f2z]) || any(isinf, [f2x, f2y, f2z])
-         nstep = n; break
-      end
-      # SUBSTEP #3
-      xpos = x[n] + f2x*ds/2.0
-      ypos = y[n] + f2y*ds/2.0
-      zpos = z[n] + f2z*ds/2.0
-      ix = floor(Int, xpos)
-      iy = floor(Int, ypos)
-      iz = floor(Int, zpos)
-      if DoBreak(ix, iy, iz, iSize, jSize, kSize); nstep = n; break end
+		if precompute
+			f2x = grid_interp(xpos, ypos, zpos, ix, iy, iz, fx)
+			f2y = grid_interp(xpos, ypos, zpos, ix, iy, iz, fy)
+			f2z = grid_interp(xpos, ypos, zpos, ix, iy, iz, fz)
+		else
+			f2x, f2y, f2z =
+				grid_interp_normalized(xpos, ypos, zpos, ix, iy, iz, ux, uy, uz, dx, dy, dz)
+		end
+		if any(isnan, [f2x, f2y, f2z]) || any(isinf, [f2x, f2y, f2z])
+			nstep = n
+			break
+		end
+		# SUBSTEP #3
+		xpos = x[n] + f2x*ds/2
+		ypos = y[n] + f2y*ds/2
+		zpos = z[n] + f2z*ds/2
+		ix = floor(Int, xpos)
+		iy = floor(Int, ypos)
+		iz = floor(Int, zpos)
+		if DoBreak(ix, iy, iz, iSize, jSize, kSize)
+			nstep = n
+			break
+		end
 
-      f3x = grid_interp(xpos, ypos, zpos, ix, iy, iz, fx)
-      f3y = grid_interp(xpos, ypos, zpos, ix, iy, iz, fy)
-      f3z = grid_interp(xpos, ypos, zpos, ix, iy, iz, fz)
-      if any(isnan,[f3x, f3y, f3z]) || any(isinf, [f3x, f3y, f3z])
-         nstep = n; break
-      end
+		if precompute
+			f3x = grid_interp(xpos, ypos, zpos, ix, iy, iz, fx)
+			f3y = grid_interp(xpos, ypos, zpos, ix, iy, iz, fy)
+			f3z = grid_interp(xpos, ypos, zpos, ix, iy, iz, fz)
+		else
+			f3x, f3y, f3z =
+				grid_interp_normalized(xpos, ypos, zpos, ix, iy, iz, ux, uy, uz, dx, dy, dz)
+		end
+		if any(isnan, [f3x, f3y, f3z]) || any(isinf, [f3x, f3y, f3z])
+			nstep = n
+			break
+		end
 
-      # SUBSTEP #4
-      xpos = x[n] + f3x*ds
-      ypos = y[n] + f3y*ds
-      zpos = z[n] + f3z*ds
-      ix = floor(Int, xpos)
-      iy = floor(Int, ypos)
-      iz = floor(Int, zpos)
-      if DoBreak(ix, iy, iz, iSize, jSize, kSize); nstep = n; break end
+		# SUBSTEP #4
+		xpos = x[n] + f3x*ds
+		ypos = y[n] + f3y*ds
+		zpos = z[n] + f3z*ds
+		ix = floor(Int, xpos)
+		iy = floor(Int, ypos)
+		iz = floor(Int, zpos)
+		if DoBreak(ix, iy, iz, iSize, jSize, kSize)
+			nstep = n
+			break
+		end
 
-      f4x = grid_interp(xpos, ypos, zpos, ix, iy, iz, fx)
-      f4y = grid_interp(xpos, ypos, zpos, ix, iy, iz, fy)
-      f4z = grid_interp(xpos, ypos, zpos, ix, iy, iz, fz)
-      if any(isnan,[f4x, f4y, f4z]) || any(isinf, [f4x, f4y, f4z])
-         nstep = n; break
-      end
+		if precompute
+			f4x = grid_interp(xpos, ypos, zpos, ix, iy, iz, fx)
+			f4y = grid_interp(xpos, ypos, zpos, ix, iy, iz, fy)
+			f4z = grid_interp(xpos, ypos, zpos, ix, iy, iz, fz)
+		else
+			f4x, f4y, f4z =
+				grid_interp_normalized(xpos, ypos, zpos, ix, iy, iz, ux, uy, uz, dx, dy, dz)
+		end
+		if any(isnan, [f4x, f4y, f4z]) || any(isinf, [f4x, f4y, f4z])
+			nstep = n
+			break
+		end
 
-      # Perform the full step using all substeps
-      @muladd x[n+1] = x[n] + ds/6 * (f1x + f2x*2 + f3x*2 + f4x)
-      @muladd y[n+1] = y[n] + ds/6 * (f1y + f2y*2 + f3y*2 + f4y)
-      @muladd z[n+1] = z[n] + ds/6 * (f1z + f2z*2 + f3z*2 + f4z)
+		# Perform the full step using all substeps
+		@muladd x[n+1] = x[n] + ds/6 * (f1x + f2x*2 + f3x*2 + f4x)
+		@muladd y[n+1] = y[n] + ds/6 * (f1y + f2y*2 + f3y*2 + f4y)
+		@muladd z[n+1] = z[n] + ds/6 * (f1z + f2z*2 + f3z*2 + f4z)
 
-      nstep = n
-   end
+		nstep = n
+	end
 
-   # Convert traced points to original coordinate system.
-   @inbounds @simd for i in 1:nstep
-      @muladd x[i] = x[i]*dx + xGrid[1]
-      @muladd y[i] = y[i]*dy + yGrid[1]
-      @muladd z[i] = z[i]*dz + zGrid[1]
-   end
+	# Convert traced points to original coordinate system.
+	@inbounds @simd for i in 1:nstep
+		@muladd x[i] = x[i]*dx + xGrid[1]
+		@muladd y[i] = y[i]*dy + yGrid[1]
+		@muladd z[i] = z[i]*dz + zGrid[1]
+	end
 
-   x[1:nstep], y[1:nstep], z[1:nstep]
+	x[1:nstep], y[1:nstep], z[1:nstep]
 end
 
 """
 	 trace3d_euler(fieldx, fieldy, fieldz, startx, starty, startz, gridx, gridy, gridz;
-       maxstep=20000, ds=0.01)
+		 maxstep=20000, ds=0.01)
 
 Given a 3D vector field, trace a streamline from a given point to the edge of the vector
 field. The field is integrated using Euler's method. Only valid for regular grid with
@@ -250,38 +403,40 @@ The field can be in both `meshgrid` or `ndgrid` (default) format.
 Supporting `direction` of {"both","forward","backward"}.
 """
 function trace3d_euler(fieldx, fieldy, fieldz, startx::T, starty::T, startz::T,
-   gridx, gridy, gridz; maxstep::Int=20000, ds::T=0.01, gridtype::String="ndgrid",
-   direction::String="both") where T<:AbstractFloat
+	gridx, gridy, gridz; maxstep::Int = 20000, ds::T = 0.01, gridtype::String = "ndgrid",
+	direction::String = "both") where T <: AbstractFloat
 
-   if gridtype == "ndgrid"
-      fx, fy, fz = fieldx, fieldy, fieldz
-   else # meshgrid
-      fx, fy, fz = permutedims(fieldx), permutedims(fieldy), permutedims(fieldz)
-   end
+	if gridtype == "ndgrid"
+		fx, fy, fz = fieldx, fieldy, fieldz
+	else # meshgrid
+		fx, fy, fz = permutedims(fieldx), permutedims(fieldy), permutedims(fieldz)
+	end
 
-   if direction == "forward"
-      xt, yt, zt = euler(maxstep, ds, startx,starty,startz, gridx,gridy,gridz, fx, fy, fz)
-   elseif direction == "backward"
-      xt, yt, zt = euler(maxstep, ds, startx,starty,startz, gridx,gridy,gridz, -fx,-fy,-fz)
-   else
-      x1, y1, z1 = euler(floor(Int, maxstep/2), ds, startx, starty, startz,
-         gridx, gridy, gridz, -fx, -fy, -fz)
-      blen = length(x1)
-      x2, y2, z2 = euler(maxstep-blen, ds, startx, starty, startz,
-         gridx, gridy, gridz, fx, fy, fz)
-      # concatenate with duplicates removed
-      xt = vcat(reverse!(x1), x2[2:end])
-      yt = vcat(reverse!(y1), y2[2:end])
-      zt = vcat(reverse!(z1), z2[2:end])
-   end
+	if direction == "forward"
+		xt, yt, zt =
+			euler(maxstep, ds, startx, starty, startz, gridx, gridy, gridz, fx, fy, fz)
+	elseif direction == "backward"
+		xt, yt, zt =
+			euler(maxstep, -ds, startx, starty, startz, gridx, gridy, gridz, fx, fy, fz)
+	else
+		x1, y1, z1 = euler(floor(Int, maxstep/2), -ds, startx, starty, startz,
+			gridx, gridy, gridz, fx, fy, fz)
+		blen = length(x1)
+		x2, y2, z2 = euler(maxstep-blen, ds, startx, starty, startz,
+			gridx, gridy, gridz, fx, fy, fz)
+		# concatenate with duplicates removed
+		xt = vcat(reverse!(x1), x2[2:end])
+		yt = vcat(reverse!(y1), y2[2:end])
+		zt = vcat(reverse!(z1), z2[2:end])
+	end
 
-   xt, yt, zt
+	xt, yt, zt
 end
 
 
 """
 	 trace3d_rk4(fieldx, fieldy, fieldz, startx, starty, startz, gridx, gridy, gridz;
-       maxstep=20000, ds=0.01)
+		 maxstep=20000, ds=0.01)
 
 Given a 3D vector field, trace a streamline from a given point to the edge of the vector
 field. The field is integrated using Euler's method. Only valid for regular grid with
@@ -290,70 +445,71 @@ The field can be in both `meshgrid` or `ndgrid` (default) format.
 See also [`trace3d_euler`](@ref).
 """
 function trace3d_rk4(fieldx, fieldy, fieldz, startx::T, starty::T, startz::T,
-   gridx, gridy, gridz; maxstep::Int=20000, ds::T=0.01, gridtype::String="ndgrid",
-   direction::String="both") where T<:AbstractFloat
+	gridx, gridy, gridz; maxstep::Int = 20000, ds::T = 0.01, gridtype::String = "ndgrid",
+	direction::String = "both") where T <: AbstractFloat
 
-   if gridtype == "ndgrid"
-      fx, fy, fz = fieldx, fieldy, fieldz
-   else # meshgrid
-      fx, fy, fz = permutedims(fieldx), permutedims(fieldy), permutedims(fieldz)
-   end
+	if gridtype == "ndgrid"
+		fx, fy, fz = fieldx, fieldy, fieldz
+	else # meshgrid
+		fx, fy, fz = permutedims(fieldx), permutedims(fieldy), permutedims(fieldz)
+	end
 
-   if direction == "forward"
-      xt, yt, zt = rk4(maxstep, ds, startx,starty,startz, gridx,gridy,gridz, fx, fy, fz)
-   elseif direction == "backward"
-      xt, yt, zt = rk4(maxstep, ds, startx,starty,startz, gridx,gridy,gridz, -fx,-fy,-fz)
-   else
-      x1, y1, z1 = rk4(floor(Int,maxstep/2), ds, startx, starty, startz,
-         gridx, gridy, gridz, -fx, -fy, -fz)
-      blen = length(x1)
-      x2, y2, z2 = rk4(maxstep-blen, ds, startx, starty, startz,
-         gridx, gridy, gridz, fx, fy, fz)
-      # concatenate with duplicates removed
-      xt = vcat(reverse!(x1), x2[2:end])
-      yt = vcat(reverse!(y1), y2[2:end])
-      zt = vcat(reverse!(z1), z2[2:end])
-   end
+	if direction == "forward"
+		xt, yt, zt = rk4(maxstep, ds, startx, starty, startz, gridx, gridy, gridz, fx, fy, fz)
+	elseif direction == "backward"
+		xt, yt, zt =
+			rk4(maxstep, -ds, startx, starty, startz, gridx, gridy, gridz, fx, fy, fz)
+	else
+		x1, y1, z1 = rk4(floor(Int, maxstep/2), -ds, startx, starty, startz,
+			gridx, gridy, gridz, fx, fy, fz)
+		blen = length(x1)
+		x2, y2, z2 = rk4(maxstep-blen, ds, startx, starty, startz,
+			gridx, gridy, gridz, fx, fy, fz)
+		# concatenate with duplicates removed
+		xt = vcat(reverse!(x1), x2[2:end])
+		yt = vcat(reverse!(y1), y2[2:end])
+		zt = vcat(reverse!(z1), z2[2:end])
+	end
 
-   xt, yt, zt
+	xt, yt, zt
 end
 
 """
-    trace3d_euler(fieldx, fieldy, fieldz, startx, starty, startz, grid::CartesianGrid;
+	 trace3d_euler(fieldx, fieldy, fieldz, startx, starty, startz, grid::CartesianGrid;
 		 maxstep=20000, ds=0.01, gridtype="ndgrid", direction="both")
 
 See also [`trace3d_rk4`](@ref).
 """
 function trace3d_euler(fieldx::F, fieldy::F, fieldz::F, startx::T, starty::T, startz::T,
-   grid::CartesianGrid; kwargs...) where {F, T}
-   gridmin = coords(minimum(grid))
-   gridmax = coords(maximum(grid))
-   Δx = spacing(grid)
+	grid::CartesianGrid; kwargs...) where {F, T}
+	gridmin = coords(minimum(grid))
+	gridmax = coords(maximum(grid))
+	Δx = spacing(grid)
 
-   gridx = range(gridmin.x.val, gridmax.x.val, step=Δx[1].val)
-   gridy = range(gridmin.y.val, gridmax.y.val, step=Δx[2].val)
-   gridz = range(gridmin.z.val, gridmax.z.val, step=Δx[3].val)
+	gridx = range(gridmin.x.val, gridmax.x.val, step = Δx[1].val)
+	gridy = range(gridmin.y.val, gridmax.y.val, step = Δx[2].val)
+	gridz = range(gridmin.z.val, gridmax.z.val, step = Δx[3].val)
 
-   trace3d_euler(fieldx, fieldy, fieldz, startx, starty, startz, gridx, gridy, gridz;
-      kwargs...)
+	trace3d_euler(fieldx, fieldy, fieldz, startx, starty, startz, gridx, gridy, gridz;
+		kwargs...)
 end
 
 """
-    trace3d_rk4(fieldx, fieldy, fieldz, startx, starty, startz, grid::CartesianGrid;
+	 trace3d_rk4(fieldx, fieldy, fieldz, startx, starty, startz, grid::CartesianGrid;
 		 maxstep=20000, ds=0.01, gridtype="ndgrid", direction="both")
 
 See also [`trace3d_euler`](@ref).
 """
 function trace3d_rk4(fieldx::F, fieldy::F, fieldz::F, startx::T, starty::T, startz::T,
-   grid::CartesianGrid; kwargs...) where {F, T}
-   gridmin = coords(minimum(grid))
-   gridmax = coords(maximum(grid))
-   Δx = spacing(grid)
+	grid::CartesianGrid; kwargs...) where {F, T}
+	gridmin = coords(minimum(grid))
+	gridmax = coords(maximum(grid))
+	Δx = spacing(grid)
 
-   gridx = range(gridmin.x.val, gridmax.x.val, step=Δx[1].val)
-   gridy = range(gridmin.y.val, gridmax.y.val, step=Δx[2].val)
-   gridz = range(gridmin.z.val, gridmax.z.val, step=Δx[3].val)
+	gridx = range(gridmin.x.val, gridmax.x.val, step = Δx[1].val)
+	gridy = range(gridmin.y.val, gridmax.y.val, step = Δx[2].val)
+	gridz = range(gridmin.z.val, gridmax.z.val, step = Δx[3].val)
 
-   trace3d_rk4(fieldx, fieldy, fieldz, startx, starty, startz, gridx, gridy, gridz;
-      kwargs...)
+	trace3d_rk4(fieldx, fieldy, fieldz, startx, starty, startz, gridx, gridy, gridz;
+		kwargs...)
 end

--- a/src/structured3d.jl
+++ b/src/structured3d.jl
@@ -65,13 +65,12 @@ grid_interp(
 function DoBreak(iloc::Int, jloc::Int, kloc::Int, iSize::Int, jSize::Int, kSize::Int)
 	ibreak = false
 	if iloc ≥ iSize-1 || jloc ≥ jSize-1 || kloc ≥ kSize-1
-		;
 		ibreak = true
 	end
 	if iloc < 0 || jloc < 0 || kloc < 0
-		;
 		ibreak = true
 	end
+
 	ibreak
 end
 
@@ -210,7 +209,7 @@ function euler(maxstep::Int, ds::T, startx::T, starty::T, startz::T, xGrid, yGri
 
 		# Break if we leave the domain
 		if DoBreak(ix, iy, iz, iSize, jSize, kSize)
-			nstep = n;
+			nstep = n
 			break
 		end
 

--- a/src/unstructured2d.jl
+++ b/src/unstructured2d.jl
@@ -1,6 +1,6 @@
 # 2D Field tracing on a unstructured grid.
 
-const Δ = 100000. # distance to the far field point
+const Δ = 100000.0 # distance to the far field point
 const ϵ = 1e-5 # small perturbation
 
 """
@@ -9,81 +9,82 @@ const ϵ = 1e-5 # small perturbation
 2D stream tracing on unstructured quadrilateral and triangular mesh.
 """
 function trace(mesh::SimpleMesh, vx::Vector{TV}, vy::Vector{TV},
-   xstart::Vector{TX}, ystart::Vector{TX}; maxIter::Int=1000, maxLen::Float64=1000.) where
-   {TV<:AbstractFloat, TX<:AbstractFloat}
-   xStream = [fill(xs, maxIter) for xs in xstart]
-   yStream = [fill(ys, maxIter) for ys in ystart]
-   nIter = fill(maxIter, length(xStream))
+	xstart::Vector{TX}, ystart::Vector{TX}; maxIter::Int = 1000, maxLen::Float64 = 1000.0,
+) where
+	{TV <: AbstractFloat, TX <: AbstractFloat}
+	xStream = [fill(xs, maxIter) for xs in xstart]
+	yStream = [fill(ys, maxIter) for ys in ystart]
+	nIter = fill(maxIter, length(xStream))
 
-   @inbounds for iS in eachindex(xStream)
-      Pnow = Point(xStream[iS][1], yStream[iS][1])
-      P⁺ = Point(zero(TX), zero(TX))
-      cellID = getCellID(mesh, Pnow)
-      cellIDNew = 0
+	@inbounds for iS in eachindex(xStream)
+		Pnow = Point(xStream[iS][1], yStream[iS][1])
+		P⁺ = Point(zero(TX), zero(TX))
+		cellID = getCellID(mesh, Pnow)
+		cellIDNew = 0
 
-      for it in 1:maxIter
-         Pfar = Pnow + Vec(TX(vx[cellID]*Δ), TX(vy[cellID]*Δ))
-         element = getelement(mesh, cellID)
-         
-         if mesh[cellID] isa Quadrangle
-            nEdge = 4
-         elseif mesh[cellID] isa Triangle
-            nEdge = 3
-         end
+		for it in 1:maxIter
+			Pfar = Pnow + Vec(TX(vx[cellID]*Δ), TX(vy[cellID]*Δ))
+			element = getelement(mesh, cellID)
 
-         ray = Segment(Pnow, Pfar)
-         # Loop over edges
-         for i in 1:nEdge
-            j = i % nEdge + 1 
-            P = Segment(element.vertices[i], element.vertices[j]) ∩ ray
-            if P isa Point
-               P⁺ = P + Vec(TX(vx[cellID]*ϵ), TX(vy[cellID]*ϵ))
-               cellIDNew = getCellID(mesh, P⁺)
-               break
-            elseif P isa Segment
-               P⁺ = element.vertices[j] + Vec(TX(vx[cellID]*ϵ), TX(vy[cellID]*ϵ))
-               cellIDNew = getCellID(mesh, P⁺)
-               break
-            end
-         end
+			if mesh[cellID] isa Quadrangle
+				nEdge = 4
+			elseif mesh[cellID] isa Triangle
+				nEdge = 3
+			end
 
-         Pnow = P⁺
+			ray = Segment(Pnow, Pfar)
+			# Loop over edges
+			for i in 1:nEdge
+				j = i % nEdge + 1
+				P = Segment(element.vertices[i], element.vertices[j]) ∩ ray
+				if P isa Point
+					P⁺ = P + Vec(TX(vx[cellID]*ϵ), TX(vy[cellID]*ϵ))
+					cellIDNew = getCellID(mesh, P⁺)
+					break
+				elseif P isa Segment
+					P⁺ = element.vertices[j] + Vec(TX(vx[cellID]*ϵ), TX(vy[cellID]*ϵ))
+					cellIDNew = getCellID(mesh, P⁺)
+					break
+				end
+			end
 
-         xStream[iS][it+1] = Pnow.coords.x.val
-         yStream[iS][it+1] = Pnow.coords.y.val
-         nIter[iS] = it+1
+			Pnow = P⁺
 
-         if cellIDNew == 0 # hit the boundary
-            break
-         else
-            cellID = cellIDNew
-         end
-      end
-   end
+			xStream[iS][it+1] = Pnow.coords.x.val
+			yStream[iS][it+1] = Pnow.coords.y.val
+			nIter[iS] = it+1
 
-   @inbounds @simd for i in eachindex(xStream)
-      xStream[i] = xStream[i][1:nIter[i]]
-      yStream[i] = yStream[i][1:nIter[i]]
-   end
+			if cellIDNew == 0 # hit the boundary
+				break
+			else
+				cellID = cellIDNew
+			end
+		end
+	end
 
-   xStream, yStream
+	@inbounds @simd for i in eachindex(xStream)
+		xStream[i] = xStream[i][1:nIter[i]]
+		yStream[i] = yStream[i][1:nIter[i]]
+	end
+
+	xStream, yStream
 end
 
 "Return cell ID on the unstructured mesh."
 function getCellID(mesh::SimpleMesh, point::Point)
-   for (i, element) in enumerate(elements(mesh))
-      if point ∈ element
-         return i
-      end
-   end
-   return 0 # out of mesh boundary
+	for (i, element) in enumerate(elements(mesh))
+		if point ∈ element
+			return i
+		end
+	end
+	return 0 # out of mesh boundary
 end
 
 "Return the `cellID`th element of the mesh."
 function getelement(mesh::SimpleMesh, cellID::Int)
-   for (i, element) in enumerate(elements(mesh))
-      if i == cellID
-         return element
-      end
-   end
+	for (i, element) in enumerate(elements(mesh))
+		if i == cellID
+			return element
+		end
+	end
 end

--- a/src/utility/seed.jl
+++ b/src/utility/seed.jl
@@ -9,22 +9,22 @@ Generate uniform seeding points in the grid range `x` and `y` in `nsegment`. If 
 specified, use the keyword input, otherwise it will be overloaded by the 3D version seed
 generation function!
 """
-function select_seeds(x, y; nsegment=(5, 5))
-   xmin, xmax = extrema(x)
-   ymin, ymax = extrema(y)
+function select_seeds(x, y; nsegment = (5, 5))
+	xmin, xmax = extrema(x)
+	ymin, ymax = extrema(y)
 
-   dx = (xmax - xmin) / nsegment[1]
-   dy = (ymax - ymin) / nsegment[2]
+	dx = (xmax - xmin) / nsegment[1]
+	dy = (ymax - ymin) / nsegment[2]
 
-   xrange = xmin .+ dx*((1:nsegment[1]) .- 0.5)
-   yrange = ymin .+ dy*((1:nsegment[2]) .- 0.5)
+	xrange = xmin .+ dx*((1:nsegment[1]) .- 0.5)
+	yrange = ymin .+ dy*((1:nsegment[2]) .- 0.5)
 
-   seeds = zeros(eltype(x[1]), 2, prod(nsegment))
-   for i in 0:prod(nsegment)-1
-      seeds[1,i+1] = xrange[i % nsegment[1] + 1]
-      seeds[2,i+1] = yrange[i ÷ nsegment[2] + 1]
-   end
-   seeds
+	seeds = zeros(eltype(x[1]), 2, prod(nsegment))
+	for i in 0:(prod(nsegment)-1)
+		seeds[1, i+1] = xrange[i%nsegment[1]+1]
+		seeds[2, i+1] = yrange[i÷nsegment[2]+1]
+	end
+	seeds
 end
 
 """
@@ -32,25 +32,25 @@ end
 
 Generate uniform seeding points in the grid range `x`, `y` and `z` in `nsegment`.
 """
-function select_seeds(x, y, z; nsegment=(5, 5, 5))
-   xmin, xmax = extrema(x)
-   ymin, ymax = extrema(y)
-   zmin, zmax = extrema(z)
+function select_seeds(x, y, z; nsegment = (5, 5, 5))
+	xmin, xmax = extrema(x)
+	ymin, ymax = extrema(y)
+	zmin, zmax = extrema(z)
 
-   dx = (xmax - xmin) / nsegment[1]
-   dy = (ymax - ymin) / nsegment[2]
-   dz = (zmax - zmin) / nsegment[3]
+	dx = (xmax - xmin) / nsegment[1]
+	dy = (ymax - ymin) / nsegment[2]
+	dz = (zmax - zmin) / nsegment[3]
 
-   xrange = xmin .+ dx*((1:nsegment[1]) .- 0.5)
-   yrange = ymin .+ dy*((1:nsegment[2]) .- 0.5)
-   zrange = zmin .+ dz*((1:nsegment[3]) .- 0.5)
+	xrange = xmin .+ dx*((1:nsegment[1]) .- 0.5)
+	yrange = ymin .+ dy*((1:nsegment[2]) .- 0.5)
+	zrange = zmin .+ dz*((1:nsegment[3]) .- 0.5)
 
-   seeds = zeros(eltype(x[1]), 3, prod(nsegment))
-   @inbounds for k in 1:nsegment[3], j in 1:nsegment[2], i in 1:nsegment[1]
-      seeds[1,i+(j-1)*nsegment[2]+(k-1)*nsegment[2]*nsegment[3]] = xrange[i]
-      seeds[2,i+(j-1)*nsegment[2]+(k-1)*nsegment[2]*nsegment[3]] = yrange[j]
-      seeds[3,i+(j-1)*nsegment[2]+(k-1)*nsegment[2]*nsegment[3]] = zrange[k]
-   end
+	seeds = zeros(eltype(x[1]), 3, prod(nsegment))
+	@inbounds for k in 1:nsegment[3], j in 1:nsegment[2], i in 1:nsegment[1]
+		seeds[1, i+(j-1)*nsegment[2]+(k-1)*nsegment[2]*nsegment[3]] = xrange[i]
+		seeds[2, i+(j-1)*nsegment[2]+(k-1)*nsegment[2]*nsegment[3]] = yrange[j]
+		seeds[3, i+(j-1)*nsegment[2]+(k-1)*nsegment[2]*nsegment[3]] = zrange[k]
+	end
 
-   seeds
+	seeds
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,111 +2,108 @@ using FieldTracer, Meshes
 using Test
 
 @testset "FieldTracer.jl" begin
-   @testset "Seeding" begin
-      x = 0.0:0.1:1.0
-      y = 1.0:0.1:2.0
-      seeds = select_seeds(x, y; nsegment=(2,2))
-      @test seeds[:,4] == [0.75, 1.75]
-      z = 2.0:0.1:3.0
-      seeds = select_seeds(x, y, z; nsegment=(2,2,2))
-      @test seeds[:,2] == [0.75, 1.25, 2.25]
-   end
+	@testset "Seeding" begin
+		x = 0.0:0.1:1.0
+		y = 1.0:0.1:2.0
+		seeds = select_seeds(x, y; nsegment = (2, 2))
+		@test seeds[:, 4] == [0.75, 1.75]
+		z = 2.0:0.1:3.0
+		seeds = select_seeds(x, y, z; nsegment = (2, 2, 2))
+		@test seeds[:, 2] == [0.75, 1.25, 2.25]
+	end
 
-   @testset "2D structured mesh" begin
-      # bilinear interpolation function in a normalized rectangle
-      x, y = 0.1, 0.2
-      Q00, Q10, Q01, Q11 = 3.0, 40.0, 5.0, 60.0
-      out = FieldTracer.bilin_reg(x, y, Q00, Q10, Q01, Q11)
-      @test out ≈ 7.460 atol=1e-5
+	@testset "2D structured mesh" begin
+		# bilinear interpolation function in a normalized rectangle
+		x, y = 0.1, 0.2
+		Q00, Q10, Q01, Q11 = 3.0, 40.0, 5.0, 60.0
+		out = FieldTracer.bilin_reg(x, y, Q00, Q10, Q01, Q11)
+		@test out ≈ 7.460 atol=1e-5
 
-      # Euler2 and RK4 functions
-      # https://se.mathworks.com/help/matlab/ref/streamline.html
-      ds, maxstep = 0.1, 150
-      x = range(0, 1, step=0.1)
-      y = range(0, 1, step=0.1)
-      # ndgrid
-      xgrid = [i for i in x, _ in y]
-      ygrid = [j for _ in x, j in y]
-      u = copy(xgrid)
-      v = -copy(ygrid)
-      xstart = 0.1
-      ystart = 0.9
+		# Euler2 and RK4 functions
+		# https://se.mathworks.com/help/matlab/ref/streamline.html
+		ds, maxstep = 0.1, 150
+		x = range(0, 1, step = 0.1)
+		y = range(0, 1, step = 0.1)
+		# ndgrid
+		xgrid = [i for i in x, _ in y]
+		ygrid = [j for _ in x, j in y]
+		u = copy(xgrid)
+		v = -copy(ygrid)
+		xstart = 0.1
+		ystart = 0.9
 
-      xt, yt = FieldTracer.euler(maxstep, ds, xstart, ystart, x, y, u, v)
+		xt, yt = FieldTracer.euler(maxstep, ds, xstart, ystart, x, y, u, v)
+		@test length(xt) == 141
+		xt, yt = FieldTracer.euler(maxstep, ds, xstart, ystart, x, y, u, v, true)
+		@test length(xt) == 141
 
-      @test length(xt) == 141
+		xt, yt = FieldTracer.rk4(maxstep, ds, xstart, ystart, x, y, u, v)
+		@test length(xt) == 140
 
-      xt, yt = FieldTracer.rk4(maxstep, ds, xstart, ystart, x, y, u, v)
+		grid = CartesianGrid((length(x)-1, length(y)-1), (0.0, 0.0), (0.1, 0.1))
+		# default direction is both
+		xt, yt = trace(u, v, xstart, ystart, grid; alg = Euler(), maxstep, ds)
+		@test length(xt) == 148
 
-      @test length(xt) == 140
+		include("test_structured.jl")
+		# asymptotic field
+		@test test_trace_asymptote()     # single precision
+		@test test_trace_asymptote(true) # double precision
 
-      grid = CartesianGrid((length(x)-1,length(y)-1),(0.,0.),(0.1,0.1))
+		# dipole field
+		@test test_trace_dipole()        # dipole tracing in 2D
+	end
 
-      # default direction is both
-      xt, yt = trace(u, v, xstart, ystart, grid; alg=Euler(), maxstep, ds)
+	@testset "3D structured mesh" begin
+		# trilinear interpolation function in a normalized box
+		x, y, z = 0.1, 0.2, 0.3
+		Q = (3.0, 40.0, 5.0, 60.0, 3.0, 40.0, 5.0, 60.0)
+		out = FieldTracer.trilin_reg(x, y, z, Q...)
+		@test out ≈ 7.460 atol=1e-5
 
-      @test length(xt) == 148
+		x = range(0, 10, length = 15)
+		y = range(0, 10, length = 20)
+		z = range(0, 10, length = 25)
+		bx = fill(1.0, length(x), length(y), length(z))
+		by = fill(1.0, length(x), length(y), length(z))
+		bz = fill(1.0, length(x), length(y), length(z))
+		xs, ys, zs = 1.0, 1.0, 1.0
 
-      include("test_structured.jl")
-      # asymptotic field
-      @test test_trace_asymptote()     # single precision
-      @test test_trace_asymptote(true) # double precision
+		# Euler 2nd order
+		x1, y1, z1 = trace(bx, by, bz, xs, ys, zs, x, y, z;
+			alg = Euler(), ds = 0.2, maxstep = 200)
+		@test length(x1) == 170 && x1[end] ≈ y1[end] ≈ z1[end]
 
-      # dipole field
-      @test test_trace_dipole()        # dipole tracing in 2D
-   end
+		x1, y1, z1 = FieldTracer.euler(200, 0.2, xs, ys, zs, x, y, z, bx, by, bz, true)
+		@test length(x1) == 153 && x1[end] ≈ y1[end] ≈ z1[end]
 
-   @testset "3D structured mesh" begin
-      # trilinear interpolation function in a normalized box
-      x, y, z = 0.1, 0.2, 0.3
-      Q = (3.0, 40.0, 5.0, 60.0, 3.0, 40.0, 5.0, 60.0)
-      out = FieldTracer.trilin_reg(x, y, z, Q...)
-      @test out ≈ 7.460 atol=1e-5
+		# RK4 by default
+		x1, y1, z1 = trace(bx, by, bz, xs, ys, zs, x, y, z;
+			ds = 0.2, maxstep = 200, direction = "forward")
+		@test length(x1) == 152 && x1[end] ≈ y1[end] ≈ z1[end]
 
-      x = range(0, 10, length=15)
-      y = range(0, 10, length=20)
-      z = range(0, 10, length=25)
-      bx = fill(1.0, length(x), length(y), length(z))
-      by = fill(1.0, length(x), length(y), length(z))
-      bz = fill(1.0, length(x), length(y), length(z))
-      xs, ys, zs = 1.0, 1.0, 1.0
-   
-      # Euler 2nd order
-      x1, y1, z1 = trace(bx, by, bz, xs, ys, zs, x, y, z;
-         alg=Euler(), ds=0.2, maxstep=200)
+		Δx = x[2] - x[1]
+		Δy = y[2] - y[1]
+		Δz = z[2] - z[1]
 
-      @test length(x1) == 170 && x1[end] ≈ y1[end] ≈ z1[end]
+		grid = CartesianGrid((length(x)-1, length(y)-1, length(z)-1),
+			(0.0, 0.0, 0.0),
+			(Δx, Δy, Δz))
 
-      # RK4 by default
-      x1, y1, z1 = trace(bx, by, bz, xs, ys, zs, x, y, z;
-         ds=0.2, maxstep=200, direction="forward")
+		# default direction is both
+		x1, y1, z1 = trace(bx, bz, bz, xs, ys, zs, grid;
+			alg = Euler(), ds = 0.2, maxstep = 200)
+		@test length(x1) == 170 && x1[end] ≈ y1[end] ≈ z1[end]
 
-      @test length(x1) == 152 && x1[end] ≈ y1[end] ≈ z1[end]
+		# RK4 by default
+		x1, y1, z1 = trace(bx, by, bz, xs, ys, zs, x, y, z;
+			ds = 0.2, maxstep = 200, direction = "forward")
+		@test length(x1) == 152 && x1[end] ≈ y1[end] ≈ z1[end]
+	end
 
-      Δx = x[2] - x[1]
-      Δy = y[2] - y[1]
-      Δz = z[2] - z[1]
-
-      grid = CartesianGrid((length(x)-1, length(y)-1, length(z)-1),
-         (0., 0., 0.),
-         (Δx, Δy, Δz))
-
-      # default direction is both
-      x1, y1, z1 = trace(bx, bz, bz, xs, ys, zs, grid;
-         alg=Euler(), ds=0.2, maxstep=200)
-
-      @test length(x1) == 170 && x1[end] ≈ y1[end] ≈ z1[end]
-
-      # RK4 by default
-      x1, y1, z1 = trace(bx, by, bz, xs, ys, zs, x, y, z;
-         ds=0.2, maxstep=200, direction="forward")
-   
-      @test length(x1) == 152 && x1[end] ≈ y1[end] ≈ z1[end]
-   end
-
-   @testset "2D unstructured mesh" begin
-      include("test_unstructured.jl")
-      @test test_trace_unstructured2D()
-   end
+	@testset "2D unstructured mesh" begin
+		include("test_unstructured.jl")
+		@test test_trace_unstructured2D()
+	end
 
 end

--- a/test/test_structured.jl
+++ b/test/test_structured.jl
@@ -3,88 +3,89 @@
 include("utility/dipole.jl")
 
 """
-    test_trace_asymptote(issingle=false)
+	 test_trace_asymptote(issingle=false)
 
 Test streamline tracing by plotting vectors and associated streamlines through a
 simple velocity field where Vx=x, Vy=-y. Support for single and double precision
 data.
 """
-function test_trace_asymptote(issingle=false)
+function test_trace_asymptote(issingle = false)
+	# Start by creating a velocity vector field.
+	if issingle
+		xmax, ymax = 200.0f0, 20.0f0
+		x = -10.0f0:0.25f0:xmax
+		y = -10.0f0:0.25f0:ymax
+	else
+		xmax, ymax = 200.0, 20.0
+		x = -10.0:0.25:xmax
+		y = -10.0:0.25:ymax
+	end
 
-   # Start by creating a velocity vector field.
-   if issingle
-      xmax, ymax = 200.0f0, 20.0f0
-      x = -10.0f0:0.25f0:xmax
-      y = -10.0f0:0.25f0:ymax
-   else
-      xmax, ymax = 200.0, 20.0
-      x = -10.0:0.25:xmax
-      y = -10.0:0.25:ymax
-   end
+	xgrid = [i for j in y, i in x]
+	ygrid = [j for j in y, i in x]
 
-   xgrid = [i for j in y, i in x]
-   ygrid = [j for j in y, i in x]
+	if issingle
+		vx = xgrid * 1.0f0
+		vy = ygrid * -1.0f0
 
-   if issingle
-      vx = xgrid * 1.0f0
-      vy = ygrid * -1.0f0
+		xstart = 1.0f0
+		ystart = 10.0f0
+	else
+		vx = xgrid * 1.0
+		vy = ygrid * -1.0
 
-      xstart = 1.0f0
-      ystart = 10.0f0
-   else
-      vx = xgrid * 1.0
-      vy = ygrid * -1.0
+		xstart = 1.0
+		ystart = 10.0
+	end
 
-      xstart = 1.0
-      ystart = 10.0
-   end
+	ds = 0.1
+	gridtype = "meshgrid"
 
-   ds = 0.1
-   gridtype = "meshgrid"
+	x1, y1 = trace(vx, vy, xstart, ystart, x, y; alg = RK4(), ds, gridtype)
+	x2, y2 = trace(vx, vy, xstart, ystart, x, y; alg = Euler(), ds, gridtype)
 
-   x1, y1 = trace(vx, vy, xstart, ystart, x, y; alg=RK4(), ds, gridtype)
-   x2, y2 = trace(vx, vy, xstart, ystart, x, y; alg=Euler(), ds, gridtype)
+	# analytical solution const = x*y
+	c = xstart * ystart
 
-   # analytical solution const = x*y
-   c = xstart * ystart
-
-   if issingle
-      if isapprox(x1[end]*y1[end], c, atol=1e-2) && isapprox(x2[end]*y2[end], c, atol=0.13)
-         return true
-      else
-         return false
-      end
-   else
-      if isapprox(x1[end]*y1[end], c, atol=1e-5) && isapprox(x2[end]*y2[end], c, atol=0.12)
-         return true
-      else
-         return false
-      end
-   end
+	if issingle
+		if isapprox(x1[end]*y1[end], c, atol = 1e-2) &&
+			isapprox(x2[end]*y2[end], c, atol = 0.13)
+			return true
+		else
+			return false
+		end
+	else
+		if isapprox(x1[end]*y1[end], c, atol = 1e-5) &&
+			isapprox(x2[end]*y2[end], c, atol = 0.12)
+			return true
+		else
+			return false
+		end
+	end
 end
 
 "Trace field lines through a Earth like magnetic dipole field."
 function test_trace_dipole()
 
-   # Start by creating a field of unit vectors.
-   x = -100.0:5.0:101.0
-   y = -100.0:5.0:101.0
+	# Start by creating a field of unit vectors.
+	x = -100.0:5.0:101.0
+	y = -100.0:5.0:101.0
 
-   bx, by = b_hat(x, y)
+	bx, by = b_hat(x, y)
 
-   # Trace through this field.
-   xstart = 10.0
-   ystart = 25.0
-   ds = 0.1
-   gridtype = "meshgrid"
-   
-   x1, y1 = trace(bx, by, xstart, ystart, x, y; alg=RK4(), ds, gridtype)
-   x2, y2 = trace(bx, by, xstart, ystart, x, y; alg=Euler(), ds, gridtype)
+	# Trace through this field.
+	xstart = 10.0
+	ystart = 25.0
+	ds = 0.1
+	gridtype = "meshgrid"
 
-   if length(x1) == 260 && isapprox(x1[end]*y1[end], 7462.42688, atol=1e-5) &&
-      length(x2) == 262 && isapprox(x2[end]*y2[end], 7601.60590, atol=1e-5)
-      return true
-   else
-      return false
-   end
+	x1, y1 = trace(bx, by, xstart, ystart, x, y; alg = RK4(), ds, gridtype)
+	x2, y2 = trace(bx, by, xstart, ystart, x, y; alg = Euler(), ds, gridtype)
+
+	if length(x1) == 260 && isapprox(x1[end]*y1[end], 7462.42688, atol = 1e-5) &&
+		length(x2) == 262 && isapprox(x2[end]*y2[end], 7601.60590, atol = 1e-5)
+		return true
+	else
+		return false
+	end
 end

--- a/test/test_unstructured.jl
+++ b/test/test_unstructured.jl
@@ -5,34 +5,34 @@ using FieldTracer, Meshes
 
 "Check if tracing on mixed 2D unstructured grid passes."
 function test_trace_unstructured2D()
-   # Define coordinates
-   coords = zeros(2,9)
-   coords[:,1] = [1, 1]
-   coords[:,2] = [3, 1]
-   coords[:,3] = [4, 1]
-   coords[:,4] = [1, 2]
-   coords[:,5] = [2, 2]
-   coords[:,6] = [1, 3]
-   coords[:,7] = [2, 3]
-   coords[:,8] = [3, 3]
-   coords[:,9] = [4, 3]
+	# Define coordinates
+	coords = zeros(2, 9)
+	coords[:, 1] = [1, 1]
+	coords[:, 2] = [3, 1]
+	coords[:, 3] = [4, 1]
+	coords[:, 4] = [1, 2]
+	coords[:, 5] = [2, 2]
+	coords[:, 6] = [1, 3]
+	coords[:, 7] = [2, 3]
+	coords[:, 8] = [3, 3]
+	coords[:, 9] = [4, 3]
 
-   points = [Point(coords[:,i]...) for i in axes(coords, 2)]
-   tris = connect.([(2,3,9), (5,8,7), (5,2,8), (2,9,8)], Triangle)
-   quads = connect.([(1,2,5,4),(4,5,7,6)], Quadrangle)
-   mesh = SimpleMesh(points, [tris; quads])
+	points = [Point(coords[:, i]...) for i in axes(coords, 2)]
+	tris = connect.([(2, 3, 9), (5, 8, 7), (5, 2, 8), (2, 9, 8)], Triangle)
+	quads = connect.([(1, 2, 5, 4), (4, 5, 7, 6)], Quadrangle)
+	mesh = SimpleMesh(points, [tris; quads])
 
-   vx = fill(0.5, 6)
-   vy = fill(0.3, 6)
-   start = [1.5, 1.5]
-   
-   xs, ys = trace(mesh, vx, vy, [start[1]], [start[2]])
+	vx = fill(0.5, 6)
+	vy = fill(0.3, 6)
+	start = [1.5, 1.5]
 
-   if length(xs[1]) == 4 && xs[1][4] ≈ 4.000005 && ys[1][4] ≈ 3.000003
-      return true
-   else
-      return false
-   end
+	xs, ys = trace(mesh, vx, vy, [start[1]], [start[2]])
+
+	if length(xs[1]) == 4 && xs[1][4] ≈ 4.000005 && ys[1][4] ≈ 3.000003
+		return true
+	else
+		return false
+	end
 end
 
 ## Visualization

--- a/test/utility/dipole.jl
+++ b/test/utility/dipole.jl
@@ -4,7 +4,7 @@
 # Los Alamos National Security, LLC. 2010
 
 # mean value of B at the magnetic equator on the Earth's surface, [nT]
-const B₀ = 31200. 
+const B₀ = 31200.0
 
 """
 	 b_mag(x, y)
@@ -13,9 +13,9 @@ Return the strength of the dipole magnetic field in nT for a position
 `x`, `y`in units of planetary radius.
 """
 function b_mag(x, y)
-   r = @. √(x^2 + y^2)
-   cosy = y./r
-   B = @. B₀ * sqrt(1+3*cosy^2)/r^3
+	r = @. √(x^2 + y^2)
+	cosy = y ./ r
+	B = @. B₀ * sqrt(1+3*cosy^2)/r^3
 end
 
 """
@@ -25,66 +25,66 @@ Return the strength of the dipole magnetic field in nT for a position
 `x`, `y`, `z` in units of planetary radius.
 """
 function b_mag(x, y, z)
-   r = @. √(x^2 + y^2 + z^2)
-   cosθ = z ./ r
-   B = @. B₀ * sqrt(1+3*cosθ^2)/r^3
+	r = @. √(x^2 + y^2 + z^2)
+	cosθ = z ./ r
+	B = @. B₀ * sqrt(1+3*cosθ^2)/r^3
 end
 
 """
-    b_hat(x, y)
+	 b_hat(x, y)
 
 Return two arrays, `bx` and `by`, corresponding to the direction of a dipole 
 field at (`x`, `y`). The grid is organized in meshgrid (default) or ndgrid
 format.
 """
-function b_hat(x, y; gridType="meshgrid")
-   if gridType == "meshgrid"
-      xgrid = [i for _ in y, i in x]
-      ygrid = [j for j in y, _ in x]
-   else
-      xgrid = [i for i in x, _ in y]
-      ygrid = [j for _ in x, j in y]
-   end
+function b_hat(x, y; gridType = "meshgrid")
+	if gridType == "meshgrid"
+		xgrid = [i for _ in y, i in x]
+		ygrid = [j for j in y, _ in x]
+	else
+		xgrid = [i for i in x, _ in y]
+		ygrid = [j for _ in x, j in y]
+	end
 
-   r = @. sqrt(xgrid^2 + ygrid^2)
-   cosy = ygrid./r
-   sinx = xgrid./r
+	r = @. sqrt(xgrid^2 + ygrid^2)
+	cosy = ygrid ./ r
+	sinx = xgrid ./ r
 
-   denom = @. sqrt(1.0 + 3.0*cosy^2)
+	denom = @. sqrt(1.0 + 3.0*cosy^2)
 
-   br = @. 2.0 * cosy / denom
-   bθ =          sinx ./ denom
+	br = @. 2.0 * cosy / denom
+	bθ = sinx ./ denom
 
-   bx = @. br*sinx + bθ*cosy
-   by = @. br*cosy - bθ*sinx
+	bx = @. br*sinx + bθ*cosy
+	by = @. br*cosy - bθ*sinx
 
-   return bx, by
+	return bx, by
 end
 
 """
-    b_hat(x, y, z)
+	 b_hat(x, y, z)
 
 Return the direction of a 3D dipole field at given locations.
 The grid is organized in meshgrid or ndgrid (default) format.
 """
-function b_hat(x, y, z; gridType="ndgrid")
-   if gridType == "meshgrid"
-      xgrid = [i for _ in y, i in x, _ in z]
-      ygrid = [j for j in y, _ in x, _ in z]
-      zgrid = [k for _ in y, _ in x, k in z]
-   else
-      xgrid = [i for i in x, _ in y, _ in z]
-      ygrid = [j for _ in x, j in y, _ in z]
-      zgrid = [k for _ in x, _ in y, k in z]
-   end
+function b_hat(x, y, z; gridType = "ndgrid")
+	if gridType == "meshgrid"
+		xgrid = [i for _ in y, i in x, _ in z]
+		ygrid = [j for j in y, _ in x, _ in z]
+		zgrid = [k for _ in y, _ in x, k in z]
+	else
+		xgrid = [i for i in x, _ in y, _ in z]
+		ygrid = [j for _ in x, j in y, _ in z]
+		zgrid = [k for _ in x, _ in y, k in z]
+	end
 
-   r = @. sqrt(xgrid^2 + ygrid^2 + zgrid^2)
+	r = @. sqrt(xgrid^2 + ygrid^2 + zgrid^2)
 
-   bx = @. 3*xgrid*zgrid/r^5
-   by = @. 3*ygrid*zgrid/r^5
-   bz = @. (3*zgrid^2 - r^2) / r^5
+	bx = @. 3*xgrid*zgrid/r^5
+	by = @. 3*ygrid*zgrid/r^5
+	bz = @. (3*zgrid^2 - r^2) / r^5
 
-   return bx, by, bz
+	return bx, by, bz
 end
 
 """
@@ -93,56 +93,56 @@ end
 For a starting X, Y point return x and y vectors that trace the dipole field
 line that passes through the given point.
 """
-function b_line(x, y; npoints=30)
-   r = sqrt(x^2 + y^2)
-   try
-      theta = atan(x/y)
-   catch
-      @warn "ZeroDivisionError"
-      theta = pi/2.0
-   end
+function b_line(x, y; npoints = 30)
+	r = sqrt(x^2 + y^2)
+	try
+		theta = atan(x/y)
+	catch
+		@warn "ZeroDivisionError"
+		theta = pi/2.0
+	end
 
-   R = r/(sin(theta)^2)
+	R = r/(sin(theta)^2)
 
-   if x < 0
-      theta = π:π/npoints:2.0π
-   else
-      theta = 0:π/npoints:π
-   end
+	if x < 0
+		theta = π:(π/npoints):2.0π
+	else
+		theta = 0:(π/npoints):π
+	end
 
-   r_vec = @. R * sin(theta)^2
-   x_out = @. r_vec * sin(theta)
-   y_out = @. r_vec * cos(theta)
+	r_vec = @. R * sin(theta)^2
+	x_out = @. r_vec * sin(theta)
+	y_out = @. r_vec * cos(theta)
 
-   return x_out, y_out
+	return x_out, y_out
 end
 
 "A quick test of the dipole field functions."
 function test_dipole_2d()
 
-   x = -100.0:5.0:101.0
-   y = -100.0:5.0:101.0
+	x = -100.0:5.0:101.0
+	y = -100.0:5.0:101.0
 
-   x_vec, y_vec = b_hat(x,y)
+	x_vec, y_vec = b_hat(x, y)
 
-   fig = plt.figure(figsize=(10,8))
-   ax1 = plt.subplot(111)
+	fig = plt.figure(figsize = (10, 8))
+	ax1 = plt.subplot(111)
 
-   ax1.quiver(x, y, x_vec, y_vec)
+	ax1.quiver(x, y, x_vec, y_vec)
 
-   for i in -120:10:121
-      x,y = b_line(float(i), 0.0, npoints=100)
-      ax1.plot(x, y, "b")
-   end
-   for theta in π/2.0:π/100.0:3.0π/2.0
-      x = sin(theta)
-      y = cos(theta)
-      x, y = b_line(x, y, npoints=100)
-      ax1.plot(x, y, "r")
-   end
-   ax1.set_xlim([-100, 100])
-   ax1.set_ylim([-100, 100])
-   plt.title("Unit vectors for an arbitrary dipole field")
+	for i in -120:10:121
+		x, y = b_line(float(i), 0.0, npoints = 100)
+		ax1.plot(x, y, "b")
+	end
+	for theta in (π/2.0):(π/100.0):(3.0π/2.0)
+		x = sin(theta)
+		y = cos(theta)
+		x, y = b_line(x, y, npoints = 100)
+		ax1.plot(x, y, "r")
+	end
+	ax1.set_xlim([-100, 100])
+	ax1.set_ylim([-100, 100])
+	plt.title("Unit vectors for an arbitrary dipole field")
 
-   return true
+	return true
 end


### PR DESCRIPTION
This PR adds non-allocated tracing for the structured mesh. This version may involve duplicate calculations, as a tradeoff for eliminating the normalized field arrays. #61 We now switch to the non-allocated version by default.

---

As expected, in 2D it's actually slower than the allocated version. But it really doesn't matter that much.
